### PR TITLE
[DOCS] Add PR Merge Agent to README quick commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This project uses Cursor AI agents to automate common development tasks. See the
 - Commit changes: `Use Git Commit & Push Agent to commit my changes`
 - Create PR: `Use GitHub PR Creation Agent to create a pull request`
 - Review PR: `Use GitHub PR Review Agent to review PR #42`
+- Merge PR: `Use GitHub PR Merge Agent to merge PR #42`
 
 For complete agent specifications, see [`AGENT_RULES.md`](AGENT_RULES.md).
 


### PR DESCRIPTION
## Description
This PR adds the GitHub PR Merge Agent command to the README quick commands section, completing the documentation of all available agents.

## Changes Made
- **Updated** `README.md` - Added PR Merge Agent command to quick commands list

## Type of Change
- [x] Documentation update
- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Performance improvement

## Testing Done
- [x] Verified README formatting
- [x] Confirmed all agents are now documented

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated
- [x] No breaking changes
- [x] Reviewed own code

## Additional Notes
This completes the documentation of all four agents:
1. Git Commit & Push Agent
2. GitHub PR Creation Agent
3. GitHub PR Review Agent
4. GitHub PR Merge Agent (newly added)