### PR TITLE
[FIX] Force chart refresh when view becomes visible

### DIFF
--- a/composeApp/src/commonMain/kotlin/ui/CryptoListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/CryptoListScreen.kt
@@ -236,12 +236,11 @@ fun CryptoList(
                     // Only resume work when view is actually visible
                     coroutineScope.launch {
                         cryptoViewModel.reconnect()
-                        // Don't force refresh on resume - only load missing charts
                         if (visibleSymbols.isNotEmpty()) {
                             fetchJob?.cancel()
                             fetchJob = launch(Dispatchers.Default) {
                                 try {
-                                    cryptoViewModel.fetchUiKlinesForVisibleSymbols(visibleSymbols, forceRefresh = false)
+                                    cryptoViewModel.fetchUiKlinesForVisibleSymbols(visibleSymbols, forceRefresh = true)
                                 } catch (e: CancellationException) {
                                     throw e
                                 } catch (e: Exception) {


### PR DESCRIPTION
## Description
This PR fixes an issue where cryptocurrency charts were not refreshing with the latest data when users navigated back to the crypto list screen. The change ensures that charts are always refreshed when the view becomes visible, improving data freshness and user experience.

## Changes Made
- Changed `forceRefresh` parameter from `false` to `true` in `fetchUiKlinesForVisibleSymbols` call within `CryptoListScreen.kt`
- Removed outdated comment about not forcing refresh on resume
- Ensures charts display the most up-to-date data when the screen becomes visible

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance improvement

## Testing Done
- [x] Manual testing on Android
- [x] Verified charts refresh correctly when navigating back to the screen
- [x] Confirmed no regressions in chart loading behavior
- [ ] Manual testing on iOS (if applicable)
- [ ] Manual testing on Desktop (if applicable)

## Technical Details
- Modified file: `composeApp/src/commonMain/kotlin/ui/CryptoListScreen.kt`
- The change affects the `DisposableEffect` that handles view lifecycle events
- When the view becomes visible, charts for visible symbols are now fetched with `forceRefresh = true`
- This ensures users always see the latest chart data when returning to the screen

## Checklist
- [x] Code follows project style guidelines
- [x] Tests pass locally
- [x] No breaking changes
- [x] Reviewed own code

## Additional Notes
This fix improves the user experience by ensuring that chart data is always fresh when users navigate back to the crypto list screen. The previous behavior of not forcing a refresh could lead to stale data being displayed, especially if users had been away from the screen for an extended period.