### PR TITLE
[FEATURE] iOS Widget Extension with Favorites Display

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ A modern, cross-platform cryptocurrency tracking application built with Kotlin M
 - **Persistent favorites** stored locally across app sessions
 - **Quick navigation** to favorite coin details
 
-### 📱 Widgets (Android Only)
+### 📱 Widgets
 - **Home screen widget** displaying up to 4 favorite cryptocurrency pairs
 - **Real-time price data** with automatic updates every 5 minutes
 - **Interactive sparkline charts** showing 1000 data points (1-second intervals)
@@ -61,7 +61,9 @@ A modern, cross-platform cryptocurrency tracking application built with Kotlin M
 - **Theme-aware design** that matches your app theme (light/dark mode)
 - **Quick navigation** - Tap any favorite to open its coin detail screen
 - **Manual refresh** button for instant updates
-- **Rounded corners** and modern Material Design styling
+- **Platform-specific features:**
+  - **Android**: Rounded corners and modern Material Design styling
+  - **iOS**: Native WidgetKit integration with medium and large widget sizes (2 and 4 favorites respectively)
 
 ### 📈 Coin Detail Screen
 - **Interactive candlestick charts** with price history visualization
@@ -165,6 +167,21 @@ For complete agent specifications, see [`AGENT_RULES.md`](AGENT_RULES.md).
 - Minimum iOS version: 15.0
 - Requires Xcode 14.0+
 - Uses SwiftUI for app lifecycle
+- **Home Screen Widget** - Add the favorites widget to your home screen:
+  1. Long-press on home screen
+  2. Tap the "+" button in the top-left corner
+  3. Search for "UTXO" or scroll to find "UTXO Favorites"
+  4. Select widget size (Medium or Large)
+  5. Tap "Add Widget" and position on home screen
+  6. Widget automatically displays your favorite cryptocurrencies
+- Widget features:
+  - Automatic refresh every 5 minutes (managed by iOS WidgetKit)
+  - Manual refresh button (↻ icon in header)
+  - Tap any coin to view details (deep linking)
+  - Theme-aware (respects system light/dark mode)
+  - Medium widget: Displays 2 favorites with charts
+  - Large widget: Displays 4 favorites with charts
+  - Empty state message when no favorites are added
 
 ### Web
 - Built with Kotlin/Wasm

--- a/composeApp/src/androidMain/kotlin/App.android.kt
+++ b/composeApp/src/androidMain/kotlin/App.android.kt
@@ -109,3 +109,7 @@ actual fun openLink(link: String) {
     }
     context.startActivity(intent)
 }
+
+actual fun syncSettingsToWidget(settings: ui.Settings) {
+    // No-op for Android - widget reads directly from settings file
+}

--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -73,6 +73,11 @@ fun App(
     val navController: NavHostController = rememberNavController()
     val settingsState by store.updates.collectAsState(initial = ui.Settings(appTheme = AppTheme.System))
     val isDarkTheme = isDarkTheme(settingsState)
+    
+    // Sync settings to widget (iOS App Group)
+    LaunchedEffect(settingsState) {
+        settingsState?.let { syncSettingsToWidget(it) }
+    }
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     var selectedItem by rememberSaveable { mutableIntStateOf(0) }
     val networkObserver = remember { NetworkConnectivityObserver() }
@@ -273,6 +278,8 @@ expect fun createNewsHttpClient(): HttpClient
 expect fun wrapRssUrlForPlatform(url: String): String
 
 expect fun getPendingCoinDetailFromIntent(): Pair<String, String>?
+
+expect fun syncSettingsToWidget(settings: ui.Settings)
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 expect class NetworkConnectivityObserver() {

--- a/composeApp/src/desktopMain/kotlin/App.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/App.desktop.kt
@@ -105,3 +105,7 @@ actual fun openLink(link: String) {
 actual fun getPendingCoinDetailFromIntent(): Pair<String, String>? {
     return null // Not applicable for desktop
 }
+
+actual fun syncSettingsToWidget(settings: ui.Settings) {
+    // No-op for desktop - no widgets
+}

--- a/composeApp/src/wasmJsMain/kotlin/App.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/App.wasmJs.kt
@@ -72,6 +72,10 @@ actual fun getPendingCoinDetailFromIntent(): Pair<String, String>? {
     return null // Not applicable for WASM/web
 }
 
+actual fun syncSettingsToWidget(settings: ui.Settings) {
+    // No-op for WASM/web - no widgets
+}
+
 actual fun wrapRssUrlForPlatform(url: String): String {
     // Use CORS proxy for WASM/web platform to bypass CORS restrictions
     // Using allorigins.win as a reliable CORS proxy service

--- a/docs/ios/widget/WIDGET_DOCUMENTATION.md
+++ b/docs/ios/widget/WIDGET_DOCUMENTATION.md
@@ -1,0 +1,441 @@
+# iOS Widget Extension Documentation
+
+Complete guide for the UTXO iOS Widget Extension implementation.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Setup Instructions](#setup-instructions)
+3. [App Groups Configuration](#app-groups-configuration)
+4. [Features](#features)
+5. [Data Flow](#data-flow)
+6. [Widget Refresh Behavior](#widget-refresh-behavior)
+7. [Debugging](#debugging)
+8. [Testing](#testing)
+9. [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+The iOS Widget Extension displays favorite cryptocurrencies with live prices, change percentages, volumes, and sparkline charts. It matches the Android widget functionality and design.
+
+### Files Structure
+
+- `UTXOWidget.swift` - Main widget configuration and timeline provider
+- `FavoritesWidgetEntryView.swift` - SwiftUI views for widget display (medium and large sizes)
+- `WidgetDataHelper.swift` - Helper functions for data fetching, formatting, and settings reading
+- `UTXOWidgetBundle.swift` - Widget bundle entry point
+- `RefreshWidgetIntent.swift` - AppIntent for manual refresh
+- `Info.plist` - Widget extension configuration
+
+### Widget Sizes
+
+- **Medium Widget**: Shows 2 favorite coins
+- **Large Widget**: Shows 4 favorite coins
+
+---
+
+## Setup Instructions
+
+### Step 1: Add Widget Extension to Xcode Project
+
+1. **Open the project in Xcode:**
+   ```bash
+   open iosApp/iosApp.xcodeproj
+   ```
+
+2. **Add Widget Extension Target:**
+   - In Xcode, go to **File → New → Target**
+   - Select **"Widget Extension"**
+   - Product Name: `UTXOWidget`
+   - Organization Identifier: `org.androdevlinux.utxo`
+   - Language: **Swift**
+   - Include Configuration Intent: **No**
+   - Click **Finish**
+
+3. **Replace Generated Files:**
+   - Delete the auto-generated widget files in the new target
+   - Copy all files from `iosApp/UTXOWidget/` to the widget extension target folder
+   - Add them to the widget extension target in Xcode
+
+4. **Configure Signing:**
+   - Select the widget extension target
+   - Go to **Signing & Capabilities**
+   - Configure signing (use same team as main app)
+   - Bundle identifier should be: `org.androdevlinux.utxo.UTXOWidget`
+
+5. **Build Settings:**
+   - Set iOS Deployment Target to **15.0 or higher** (matching main app)
+   - Ensure Swift version is **5.0 or higher**
+
+### Step 2: Configure Deep Linking (Optional)
+
+To enable deep linking from widget to app:
+
+- In `iOSApp.swift` or `ContentView.swift`, handle URLs:
+  - `utxo://favorites` - Opens favorites screen
+  - `utxo://coin/{SYMBOL}` - Opens coin detail screen
+
+The URL scheme (`utxo://`) is already configured in the main app's `Info.plist`.
+
+---
+
+## App Groups Configuration
+
+**Important:** Widget extensions run in a separate process and **cannot access the main app's cache directory**. You must configure App Groups to share data between the app and widget.
+
+### Why App Groups Are Needed
+
+Without App Groups, the widget will show "No favorites added" even when you have favorites, because it cannot access the main app's cache directory.
+
+### Step-by-Step Setup
+
+1. **Main App Target:**
+   - Select the main app target in Xcode
+   - Go to **Signing & Capabilities**
+   - Click **+ Capability**
+   - Add **App Groups**
+   - Click **+** and add: `group.org.androdevlinux.utxo`
+   - Ensure it's checked/enabled
+
+2. **Widget Extension Target:**
+   - Select the widget extension target (`UTXOWidget`)
+   - Go to **Signing & Capabilities**
+   - Click **+ Capability**
+   - Add **App Groups**
+   - Click **+** and add: `group.org.androdevlinux.utxo`
+   - Ensure it's checked/enabled
+
+3. **Verify Both Targets:**
+   - Both targets must be signed with the **same team**
+   - Both must have the same App Group ID: `group.org.androdevlinux.utxo`
+
+### Data Sharing Implementation
+
+The app syncs settings to App Group UserDefaults when favorites change:
+
+- **Kotlin side** (`App.ios.kt`): `syncSettingsToWidget()` writes to App Group UserDefaults
+- **Swift side** (`WidgetDataHelper.swift`): Reads from App Group UserDefaults
+
+The widget reads settings from:
+1. **App Group UserDefaults**: `group.org.androdevlinux.utxo` (primary)
+2. **App Group file container**: `group.org.androdevlinux.utxo/settings.json` (fallback)
+3. **Cache directory**: `{CachesDirectory}/settings.json` (last resort)
+
+---
+
+## Features
+
+✅ **Displays up to 4 favorites** (2 in medium widget, 4 in large widget)  
+✅ **Live prices and change percentages** with color coding (green/red)  
+✅ **Volume display** with smart formatting (B, M, K)  
+✅ **Sparkline charts** for each coin  
+✅ **Automatic refresh** every 5 minutes (managed by iOS WidgetKit)  
+✅ **Manual refresh button** (↻ icon in header)  
+✅ **Theme-aware** (respects system light/dark mode)  
+✅ **Deep linking** - Tap widget to open app, tap coin to open coin details  
+✅ **Empty state** - Shows message when no favorites are added  
+
+---
+
+## Data Flow
+
+### 1. Settings Storage
+
+The widget reads settings from (in priority order):
+
+1. **App Group UserDefaults**: `group.org.androdevlinux.utxo`
+   - Key: `favPairs` (JSON string array)
+   - Key: `selectedTradingPair` (string)
+   - Key: `appTheme` (string)
+
+2. **App Group file container**: `group.org.androdevlinux.utxo/settings.json`
+
+3. **Cache directory**: `{CachesDirectory}/settings.json` (fallback)
+
+### 2. Data Fetching
+
+Widget fetches data from Binance API:
+
+- **Ticker**: `https://api.binance.com/api/v3/ticker/24hr?symbol={SYMBOL}`
+- **Chart**: `https://api.binance.com/api/v3/uiKlines?symbol={SYMBOL}&interval=1s&limit=1000`
+
+### 3. Deep Linking
+
+- **Widget → App**: `utxo://favorites` (opens app)
+- **Widget → Coin Detail**: `utxo://coin/{SYMBOL}` (opens coin detail screen)
+
+The app handles these URLs in `iOSApp.swift` and stores pending navigation in UserDefaults for Kotlin code to read.
+
+---
+
+## Widget Refresh Behavior
+
+### Automatic Refresh
+
+iOS widgets refresh automatically on a schedule managed by the system. The UTXO widget is configured to refresh every **5 minutes**.
+
+**When Widget Shows Updated Data:**
+
+1. **Automatic Refresh**: Every 5 minutes (managed by iOS)
+2. **After Adding Widget**: Widget loads immediately when first added
+3. **After App Launch**: Widget may refresh when app is opened
+4. **Manual Refresh**: Tap the refresh button (↻) in the widget header
+
+### Manual Refresh
+
+The widget includes a refresh button (↻ icon) in the header that triggers an immediate refresh via `RefreshWidgetIntent`.
+
+### Force Immediate Refresh
+
+**Option 1: Use Refresh Button (Recommended)**
+- Tap the refresh icon (↻) in the widget header
+- Widget will reload immediately
+
+**Option 2: Remove and Re-add Widget**
+1. Long press widget → Remove Widget
+2. Long press home screen → + → UTXO Favorites
+3. Widget will load with latest favorites
+
+**Option 3: Wait for Auto-Refresh**
+- Widget automatically refreshes every 5 minutes
+- No action needed
+
+### Why Widget Might Show Old Data
+
+If you:
+1. Add the widget **before** adding favorites → Widget shows "No favorites"
+2. Then add favorites in the app → Widget still shows "No favorites" until next refresh
+
+**Solution**: Tap the refresh button, wait up to 5 minutes for automatic refresh, or remove and re-add the widget.
+
+### Current Implementation
+
+The widget:
+- ✅ Reads favorites from App Group UserDefaults (shared with main app)
+- ✅ Auto-refreshes every 5 minutes
+- ✅ Shows latest data when first added
+- ✅ Supports manual refresh via button
+- ⚠️ Does NOT immediately refresh when favorites change in app (by design - iOS limitation)
+
+This is normal iOS widget behavior. Widgets are designed to refresh on a schedule, not instantly when app data changes, to preserve battery life.
+
+---
+
+## Debugging
+
+### Quick Checklist
+
+1. **App Groups Configured?**
+   - [ ] Main app target has App Groups capability with `group.org.androdevlinux.utxo`
+   - [ ] Widget extension target has App Groups capability with `group.org.androdevlinux.utxo`
+   - [ ] Both are signed with the same team
+
+2. **Check Console Logs**
+   When the widget loads, look for these logs:
+   - `WidgetDataHelper: App Group UserDefaults available` - Means App Groups is configured
+   - `WidgetDataHelper: Found favPairs JSON string:` - Means data was found
+   - `WidgetDataHelper: Successfully decoded favorites` - Means favorites were read successfully
+   - `UTXOWidget: Loaded X favorites from settings` - Final count
+
+3. **Check App Logs**
+   When you add/remove favorites, look for:
+   - `Syncing to App Group: favPairs=[...]` - Means sync is being called
+   - `Successfully synced settings to App Group UserDefaults` - Means sync succeeded
+
+### How to See Widget Extension Logs
+
+Widget extensions run in a **separate process** from your main app, so their logs appear separately in Xcode.
+
+**Method 1: Run Widget Extension Target**
+1. In Xcode, select the **UTXOWidget** scheme (not the main app)
+2. Run the widget extension target
+3. When prompted, choose a simulator/device
+4. The widget will appear and you'll see its logs in the console
+
+**Method 2: Filter Console Logs**
+1. Run your main app normally
+2. In Xcode Console, use the filter/search box
+3. Type: `UTXOWidget` or `WidgetDataHelper`
+4. This will show only widget-related logs
+
+**Method 3: Check System Console (macOS)**
+1. Open Console.app (Applications → Utilities → Console)
+2. Filter by your app name or "UTXOWidget"
+3. Widget logs will appear here
+
+### What to Look For
+
+When the widget loads, you should see logs like:
+
+```
+WidgetDataHelper: Attempting to read from App Group UserDefaults...
+WidgetDataHelper: ✅ App Group UserDefaults available
+WidgetDataHelper: All UserDefaults keys: [...]
+WidgetDataHelper: ✅ Found favPairs JSON string: ["BTCUSDT"]
+WidgetDataHelper: ✅ Successfully decoded favorites: ["BTCUSDT"]
+UTXOWidget: ✅ Found 1 favorites
+```
+
+### Common Issues
+
+**Issue: "App Group UserDefaults not available"**
+- **Solution:** App Groups capability is not configured. Add it to both targets in Xcode.
+
+**Issue: "No favPairs key found in UserDefaults"**
+- **Solution:** The app isn't syncing. Check if `syncSettingsToWidget` is being called when favorites change.
+
+**Issue: "Failed to decode favPairs JSON"**
+- **Solution:** JSON format mismatch. Check the console for the actual JSON string.
+
+**Issue: Widget shows "No favorites added"**
+- **Solution:** 
+  - Make sure you have added favorites in the app
+  - Check that settings.json exists in cache directory or app group
+  - Verify App Groups are configured correctly
+
+**Issue: Widget doesn't update**
+- **Solution:** 
+  - iOS manages widget updates automatically
+  - Updates occur every 5 minutes or when system determines appropriate
+  - You can force refresh by tapping the refresh button or removing and re-adding the widget
+
+**Issue: Deep linking doesn't work**
+- **Solution:** 
+  - Ensure URL scheme is configured in Info.plist (already done)
+  - Check that the app handles URLs in `iOSApp.swift` (already implemented)
+
+### Test UserDefaults Access
+
+To verify the widget can read from App Group UserDefaults, add this test code temporarily to your widget:
+
+Add this to `UTXOWidget.swift` in the `loadFavoritesData()` function, right at the start:
+
+```swift
+// TEST: Direct UserDefaults access
+if let testDefaults = UserDefaults(suiteName: "group.org.androdevlinux.utxo") {
+    print("🔵 TEST: App Group UserDefaults accessible")
+    let allKeys = testDefaults.dictionaryRepresentation().keys
+    print("🔵 TEST: All keys: \(Array(allKeys))")
+    
+    if let testFavPairs = testDefaults.string(forKey: "favPairs") {
+        print("🔵 TEST: ✅ Found favPairs: \(testFavPairs)")
+    } else {
+        print("🔵 TEST: ❌ favPairs not found as string")
+        if let testObject = testDefaults.object(forKey: "favPairs") {
+            print("🔵 TEST: Found as object: \(testObject), type: \(type(of: testObject))")
+        } else {
+            print("🔵 TEST: ❌ favPairs key doesn't exist")
+        }
+    }
+} else {
+    print("🔵 TEST: ❌ Cannot access App Group UserDefaults")
+}
+```
+
+### Verify App Groups Setup
+
+Run this in Xcode Console while debugging the widget:
+
+```swift
+if let defaults = UserDefaults(suiteName: "group.org.androdevlinux.utxo") {
+    print("App Group available!")
+    print("Keys: \(defaults.dictionaryRepresentation().keys)")
+    if let favPairs = defaults.string(forKey: "favPairs") {
+        print("favPairs: \(favPairs)")
+    }
+} else {
+    print("App Group NOT available - check configuration")
+}
+```
+
+---
+
+## Testing
+
+### Build and Test
+
+1. **Build the widget extension target**
+2. **Run the app on a device or simulator**
+3. **Add the widget to home screen:**
+   - Long press on home screen
+   - Tap the "+" button
+   - Search for "Favorites" or "UTXO"
+   - Select widget size (Medium or Large)
+   - Add to home screen
+
+### Manual Test Flow
+
+1. Open the app
+2. Add a favorite (e.g., BTCUSDT)
+3. Check Xcode Console - you should see sync logs:
+   ```
+   Syncing to App Group: favPairs=[BTCUSDT]
+   Successfully synced settings to App Group UserDefaults
+   ```
+4. Force refresh the widget:
+   - Tap the refresh button (↻) in the widget header, OR
+   - Remove and re-add the widget
+5. Check widget logs - should see favorites:
+   ```
+   UTXOWidget: ✅ Found 1 favorites
+   ```
+
+---
+
+## Troubleshooting
+
+### Build Errors
+
+- **Issue:** Build fails with missing symbols
+  - **Solution:** Ensure all files are added to the widget extension target in Xcode
+
+- **Issue:** Swift version errors
+  - **Solution:** Ensure Swift version is 5.0 or higher
+
+- **Issue:** iOS Deployment Target errors
+  - **Solution:** Set iOS Deployment Target to 15.0 or higher (matching main app)
+
+### Runtime Issues
+
+- **Issue:** Widget crashes on launch
+  - **Solution:** Check that all required files are included in the widget target
+  - **Solution:** Verify Info.plist is correctly configured
+
+- **Issue:** Widget shows blank screen
+  - **Solution:** Check console logs for errors
+  - **Solution:** Verify data fetching is working (check network logs)
+
+### Data Issues
+
+- **Issue:** Widget shows "No favorites added" but you have favorites
+  - **Solution:** Verify App Groups are configured correctly
+  - **Solution:** Check that `syncSettingsToWidget` is being called
+  - **Solution:** Check console logs for data sync errors
+
+- **Issue:** Widget shows old data
+  - **Solution:** Tap the refresh button
+  - **Solution:** Wait for automatic refresh (up to 5 minutes)
+  - **Solution:** Remove and re-add the widget
+
+---
+
+## Notes
+
+- Widget updates are managed by iOS WidgetKit (automatic refresh every 5 minutes)
+- Widget has limited network access and execution time
+- Charts are rendered using SwiftUI Path (Charts framework not available in widgets)
+- Widget respects system appearance (light/dark mode)
+- The widget matches the Android widget functionality and design
+- Widget extensions run in a separate process from the main app
+- App Groups are required for data sharing between app and widget
+
+---
+
+## Additional Resources
+
+- [Apple WidgetKit Documentation](https://developer.apple.com/documentation/widgetkit)
+- [App Groups Documentation](https://developer.apple.com/documentation/xcode/configuring-app-groups)
+- [Widget Extension Guide](https://developer.apple.com/documentation/widgetkit/creating-a-widget-extension)
+

--- a/iosApp/UTXOWidget/AppIntent.swift
+++ b/iosApp/UTXOWidget/AppIntent.swift
@@ -1,0 +1,19 @@
+//
+//  AppIntent.swift
+//  UTXOWidget
+//
+//  Created by Prashant Gahlot on 21/12/25.
+//  Copyright © 2025 orgName. All rights reserved.
+//
+
+import WidgetKit
+import AppIntents
+
+struct ConfigurationAppIntent: WidgetConfigurationIntent {
+    static var title: LocalizedStringResource { "Configuration" }
+    static var description: IntentDescription { "This is an example widget." }
+
+    // An example configurable parameter.
+    @Parameter(title: "Favorite Emoji", default: "😃")
+    var favoriteEmoji: String
+}

--- a/iosApp/UTXOWidget/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/iosApp/UTXOWidget/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iosApp/UTXOWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/iosApp/UTXOWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iosApp/UTXOWidget/Assets.xcassets/Contents.json
+++ b/iosApp/UTXOWidget/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iosApp/UTXOWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/iosApp/UTXOWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iosApp/UTXOWidget/FavoritesWidgetEntryView.swift
+++ b/iosApp/UTXOWidget/FavoritesWidgetEntryView.swift
@@ -1,0 +1,243 @@
+import WidgetKit
+import SwiftUI
+import AppIntents
+
+struct FavoritesWidgetEntryView: View {
+    var entry: FavoritesWidgetEntry
+    @Environment(\.widgetFamily) var family
+    
+    var body: some View {
+        Group {
+            switch family {
+            case .systemMedium:
+                MediumWidgetView(entry: entry)
+            case .systemLarge:
+                LargeWidgetView(entry: entry)
+            default:
+                MediumWidgetView(entry: entry)
+            }
+        }
+        .widgetURL(URL(string: "utxo://favorites"))
+    }
+}
+
+struct MediumWidgetView: View {
+    var entry: FavoritesWidgetEntry
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack(spacing: 0) {
+                Text("Your Favorites")
+                    .font(.headline)
+                    .fontWeight(.bold)
+                Spacer()
+                Button(intent: RefreshWidgetIntent()) {
+                    RefreshIconView(isRefreshing: entry.isRefreshing)
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+            .padding(.bottom, 8)
+            .padding(.horizontal, 0)
+            
+            if entry.isLoading {
+                Spacer()
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+                Spacer()
+            } else if let errorMessage = entry.errorMessage {
+                Spacer()
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                Spacer()
+            } else if entry.favorites.isEmpty {
+                Spacer()
+                Text("No favorites added")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Spacer()
+            } else {
+                // Show up to 2 favorites in medium widget
+                ForEach(Array(entry.favorites.prefix(2))) { favorite in
+                    FavoriteRowView(favorite: favorite)
+                    if favorite.id != entry.favorites.prefix(2).last?.id {
+                        Divider()
+                            .padding(.vertical, 4)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 12)
+    }
+}
+
+struct LargeWidgetView: View {
+    var entry: FavoritesWidgetEntry
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack(spacing: 0) {
+                Text("Your Favorites")
+                    .font(.headline)
+                    .fontWeight(.bold)
+                Spacer()
+                Button(intent: RefreshWidgetIntent()) {
+                    RefreshIconView(isRefreshing: entry.isRefreshing)
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+            .padding(.bottom, 8)
+            .padding(.horizontal, 0)
+            
+            if entry.isLoading {
+                Spacer()
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+                Spacer()
+            } else if let errorMessage = entry.errorMessage {
+                Spacer()
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                Spacer()
+            } else if entry.favorites.isEmpty {
+                Spacer()
+                Text("No favorites added")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Spacer()
+            } else {
+                // Show up to 4 favorites in large widget
+                ForEach(Array(entry.favorites.prefix(4).enumerated()), id: \.element.id) { index, favorite in
+                    FavoriteRowView(favorite: favorite)
+                    if index < entry.favorites.prefix(4).count - 1 {
+                        Divider()
+                            .padding(.vertical, 4)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 12)
+    }
+}
+
+struct FavoriteRowView: View {
+    let favorite: FavoritesWidgetEntry.FavoriteCoin
+    
+    var body: some View {
+        Link(destination: URL(string: "utxo://coin/\(favorite.symbol)") ?? URL(string: "utxo://favorites")!) {
+            HStack(spacing: 8) {
+                // No horizontal padding on the row itself
+                // Left: Symbol and Volume
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(alignment: .firstTextBaseline, spacing: 2) {
+                        Text(favorite.baseSymbol)
+                            .font(.system(size: 18, weight: .bold))
+                        Text("/")
+                            .font(.system(size: 18, weight: .bold))
+                        Text(favorite.quoteSymbol)
+                            .font(.system(size: 14))
+                            .foregroundColor(.secondary)
+                    }
+                    Text(favorite.volume)
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+                }
+                
+                Spacer()
+                
+                // Center: Chart
+                if !favorite.chartData.isEmpty {
+                    SparklineChartView(data: favorite.chartData, isPositive: favorite.changePercent >= 0)
+                        .frame(width: 80, height: 40)
+                } else {
+                    Rectangle()
+                        .fill(Color.clear)
+                        .frame(width: 80, height: 40)
+                }
+                
+                Spacer()
+                
+                // Right: Change and Price
+                VStack(alignment: .trailing, spacing: 4) {
+                    Text(formatChangePercent(favorite.changePercent))
+                        .font(.system(size: 13))
+                        .foregroundColor(favorite.changePercent >= 0 ? .green : .red)
+                    Text(favorite.price)
+                        .font(.system(size: 13))
+                }
+            }
+            .padding(.vertical, 4)
+            .padding(.horizontal, 0)
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+    
+    private func formatChangePercent(_ value: Double) -> String {
+        let sign = value >= 0 ? "+" : ""
+        return String(format: "%@%.2f%%", sign, value)
+    }
+}
+
+// Refresh icon with visual feedback
+struct RefreshIconView: View {
+    let isRefreshing: Bool
+    
+    var body: some View {
+        Image(systemName: isRefreshing ? "arrow.clockwise.circle.fill" : "arrow.clockwise")
+            .font(.system(size: 14))
+            .foregroundColor(isRefreshing ? .blue.opacity(0.7) : .blue)
+            .rotationEffect(.degrees(isRefreshing ? 90 : 0))
+            .symbolEffect(.pulse, isActive: isRefreshing)
+    }
+}
+
+// Simple sparkline chart view for widgets (Charts framework not available in widgets)
+struct SparklineChartView: View {
+    let data: [Double]
+    let isPositive: Bool
+    
+    var body: some View {
+        GeometryReader { geometry in
+            Path { path in
+                guard !data.isEmpty else { return }
+                
+                let minValue = data.min() ?? 0
+                let maxValue = data.max() ?? 0
+                let range = maxValue - minValue
+                
+                guard range > 0 else { return }
+                
+                let width = geometry.size.width
+                let height = geometry.size.height
+                let padding: CGFloat = 2
+                let chartWidth = width - padding * 2
+                let chartHeight = height - padding * 2
+                
+                for (index, value) in data.enumerated() {
+                    let x = padding + (CGFloat(index) / CGFloat(max(data.count - 1, 1))) * chartWidth
+                    let normalizedValue = (value - minValue) / range
+                    let y = padding + chartHeight - (normalizedValue * chartHeight)
+                    
+                    if index == 0 {
+                        path.move(to: CGPoint(x: x, y: y))
+                    } else {
+                        path.addLine(to: CGPoint(x: x, y: y))
+                    }
+                }
+            }
+            .stroke(isPositive ? Color.green : Color.red, lineWidth: 2)
+        }
+    }
+}
+

--- a/iosApp/UTXOWidget/Info.plist
+++ b/iosApp/UTXOWidget/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/iosApp/UTXOWidget/RefreshWidgetIntent.swift
+++ b/iosApp/UTXOWidget/RefreshWidgetIntent.swift
@@ -1,0 +1,24 @@
+import AppIntents
+import WidgetKit
+
+struct RefreshWidgetIntent: AppIntent {
+    static var title: LocalizedStringResource = "Refresh Widget"
+    static var description = IntentDescription("Refresh the favorites widget data")
+    
+    func perform() async throws -> some IntentResult {
+        // Set refreshing state to show visual feedback
+        FavoritesTimelineProvider.isRefreshing = true
+        
+        // Reload widget timeline immediately to show refreshing state
+        WidgetCenter.shared.reloadTimelines(ofKind: "UTXOWidget")
+        
+        // Small delay to show visual feedback, then reload with actual data
+        try? await Task.sleep(nanoseconds: 300_000_000) // 0.3 seconds
+        
+        // Reload again to fetch and display new data (will reset isRefreshing to false)
+        WidgetCenter.shared.reloadTimelines(ofKind: "UTXOWidget")
+        
+        return .result()
+    }
+}
+

--- a/iosApp/UTXOWidget/UTXOWidget.swift
+++ b/iosApp/UTXOWidget/UTXOWidget.swift
@@ -1,0 +1,211 @@
+//
+//  UTXOWidget.swift
+//  UTXOWidget
+//
+//  Created by Prashant Gahlot on 21/12/25.
+//  Copyright © 2025 orgName. All rights reserved.
+//
+
+import WidgetKit
+import SwiftUI
+
+struct UTXOWidget: Widget {
+    let kind: String = "UTXOWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: FavoritesTimelineProvider()) { entry in
+            FavoritesWidgetEntryView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+                .padding(.horizontal, 0)
+        }
+        .configurationDisplayName("Favorites")
+        .description("Display your favorite cryptocurrencies with live prices and charts.")
+        .supportedFamilies([.systemMedium, .systemLarge])
+    }
+}
+
+struct FavoritesWidgetEntry: TimelineEntry {
+    let date: Date
+    let favorites: [FavoriteCoin]
+    let isLoading: Bool
+    let isRefreshing: Bool
+    let errorMessage: String?
+    
+    struct FavoriteCoin: Identifiable {
+        let id: String
+        let symbol: String
+        let baseSymbol: String
+        let quoteSymbol: String
+        let price: String
+        let changePercent: Double
+        let volume: String
+        let chartData: [Double]
+    }
+}
+
+struct FavoritesTimelineProvider: TimelineProvider {
+    func placeholder(in context: Context) -> FavoritesWidgetEntry {
+        FavoritesWidgetEntry(
+            date: Date(),
+            favorites: [
+                .init(id: "1", symbol: "BTCUSDT", baseSymbol: "BTC", quoteSymbol: "USDT", price: "50,000", changePercent: 2.5, volume: "1.2B", chartData: []),
+                .init(id: "2", symbol: "ETHUSDT", baseSymbol: "ETH", quoteSymbol: "USDT", price: "3,000", changePercent: -1.2, volume: "800M", chartData: [])
+            ],
+            isLoading: false,
+            isRefreshing: false,
+            errorMessage: nil
+        )
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (FavoritesWidgetEntry) -> ()) {
+        let entry = placeholder(in: context)
+        completion(entry)
+    }
+    
+    // Track refresh state
+    static var isRefreshing = false
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<FavoritesWidgetEntry>) -> ()) {
+        Task {
+            // Check if this is a refresh request
+            let wasRefreshing = FavoritesTimelineProvider.isRefreshing
+            
+            // If refreshing, create an immediate refreshing entry for visual feedback
+            if wasRefreshing {
+                let refreshingEntry = FavoritesWidgetEntry(
+                    date: Date(),
+                    favorites: [],
+                    isLoading: true,
+                    isRefreshing: true,
+                    errorMessage: nil
+                )
+                // Schedule immediate refresh
+                let immediateTimeline = Timeline(entries: [refreshingEntry], policy: .after(Date()))
+                completion(immediateTimeline)
+            }
+            
+            // Load actual data
+            let entry = await loadFavoritesData()
+            
+            // Schedule next update in 5 minutes
+            let nextUpdate = Calendar.current.date(byAdding: .minute, value: 5, to: Date()) ?? Date()
+            // Use .after policy to ensure refresh happens at the scheduled time
+            // iOS will refresh the widget around this time (may vary based on system heuristics)
+            let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+            completion(timeline)
+        }
+    }
+    
+    private func loadFavoritesData() async -> FavoritesWidgetEntry {
+        print("🔵 UTXOWidget: loadFavoritesData() called")
+        
+        // TEST: Direct UserDefaults access check
+        if let testDefaults = UserDefaults(suiteName: "group.org.androdevlinux.utxo") {
+            print("🔵 TEST: App Group UserDefaults accessible")
+            testDefaults.synchronize() // Force sync
+            let allKeys = testDefaults.dictionaryRepresentation().keys
+            print("🔵 TEST: All keys count: \(allKeys.count)")
+            print("🔵 TEST: All keys: \(Array(allKeys))")
+            
+            if let testFavPairs = testDefaults.string(forKey: "favPairs") {
+                print("🔵 TEST: ✅ Found favPairs as string: \(testFavPairs)")
+            } else {
+                print("🔵 TEST: ❌ favPairs not found as string")
+                if let testObject = testDefaults.object(forKey: "favPairs") {
+                    print("🔵 TEST: Found as object: \(testObject)")
+                    print("🔵 TEST: Object type: \(type(of: testObject))")
+                } else {
+                    print("🔵 TEST: ❌ favPairs key doesn't exist at all")
+                }
+            }
+        } else {
+            print("🔵 TEST: ❌ Cannot access App Group UserDefaults - App Groups not configured!")
+        }
+        
+        do {
+            // Read settings
+            print("🔵 UTXOWidget: Calling WidgetDataHelper.readSettings()...")
+            let settings = try WidgetDataHelper.readSettings()
+            print("🔵 UTXOWidget: Settings read successfully")
+            print("🔵 UTXOWidget: Settings.favPairs count: \(settings.favPairs.count)")
+            print("🔵 UTXOWidget: Settings.favPairs: \(settings.favPairs)")
+            
+            // Filter out empty strings and take up to 4 favorites
+            let favorites = settings.favPairs.filter { !$0.isEmpty && !$0.trimmingCharacters(in: .whitespaces).isEmpty }.prefix(4)
+            
+            print("🔵 UTXOWidget: After filtering - Loaded \(favorites.count) favorites from settings")
+            print("🔵 UTXOWidget: Favorites list: \(Array(favorites))")
+            
+            if favorites.isEmpty {
+                print("🔵 UTXOWidget: ❌ No favorites found after filtering")
+                print("🔵 UTXOWidget: Total favPairs in settings: \(settings.favPairs.count)")
+                print("🔵 UTXOWidget: Raw favPairs: \(settings.favPairs)")
+                return FavoritesWidgetEntry(
+                    date: Date(),
+                    favorites: [],
+                    isLoading: false,
+                    isRefreshing: false,
+                    errorMessage: "No favorites added"
+                )
+            }
+            
+            print("🔵 UTXOWidget: ✅ Found \(favorites.count) favorites, proceeding to fetch data...")
+            
+            // Fetch ticker data for favorites
+            var favoriteCoins: [FavoritesWidgetEntry.FavoriteCoin] = []
+            
+            for symbol in favorites {
+                if let tickerData = await WidgetDataHelper.fetchTicker(symbol: symbol) {
+                    let (base, quote) = WidgetDataHelper.extractSymbolParts(symbol: symbol, tradingPair: settings.selectedTradingPair)
+                    let chartData = await WidgetDataHelper.fetchChartData(symbol: symbol)
+                    
+                    favoriteCoins.append(.init(
+                        id: symbol,
+                        symbol: symbol,
+                        baseSymbol: base,
+                        quoteSymbol: quote,
+                        price: WidgetDataHelper.formatPrice(tickerData.lastPrice, quoteSymbol: quote),
+                        changePercent: Double(tickerData.priceChangePercent) ?? 0.0,
+                        volume: WidgetDataHelper.formatVolume(tickerData.quoteVolume),
+                        chartData: chartData
+                    ))
+                }
+            }
+            
+            let refreshing = FavoritesTimelineProvider.isRefreshing
+            FavoritesTimelineProvider.isRefreshing = false
+            return FavoritesWidgetEntry(
+                date: Date(),
+                favorites: Array(favoriteCoins),
+                isLoading: false,
+                isRefreshing: refreshing,
+                errorMessage: nil
+            )
+        } catch {
+            let refreshing = FavoritesTimelineProvider.isRefreshing
+            FavoritesTimelineProvider.isRefreshing = false
+            return FavoritesWidgetEntry(
+                date: Date(),
+                favorites: [],
+                isLoading: false,
+                isRefreshing: refreshing,
+                errorMessage: "Failed to load data"
+            )
+        }
+    }
+}
+
+#Preview(as: .systemMedium) {
+    UTXOWidget()
+} timeline: {
+    FavoritesWidgetEntry(
+        date: Date(),
+        favorites: [
+            .init(id: "1", symbol: "BTCUSDT", baseSymbol: "BTC", quoteSymbol: "USDT", price: "50,000 USDT", changePercent: 2.5, volume: "1.2B", chartData: []),
+            .init(id: "2", symbol: "ETHUSDT", baseSymbol: "ETH", quoteSymbol: "USDT", price: "3,000 USDT", changePercent: -1.2, volume: "800M", chartData: [])
+        ],
+        isLoading: false,
+        isRefreshing: false,
+        errorMessage: nil
+    )
+}

--- a/iosApp/UTXOWidget/UTXOWidgetBundle.swift
+++ b/iosApp/UTXOWidget/UTXOWidgetBundle.swift
@@ -1,0 +1,20 @@
+//
+//  UTXOWidgetBundle.swift
+//  UTXOWidget
+//
+//  Created by Prashant Gahlot on 21/12/25.
+//  Copyright © 2025 orgName. All rights reserved.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct UTXOWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        UTXOWidget()
+        // TODO: Add UTXOWidgetControl() and UTXOWidgetLiveActivity() when implemented
+        // UTXOWidgetControl()
+        // UTXOWidgetLiveActivity()
+    }
+}

--- a/iosApp/UTXOWidget/UTXOWidgetControl.swift
+++ b/iosApp/UTXOWidget/UTXOWidgetControl.swift
@@ -1,0 +1,78 @@
+//
+//  UTXOWidgetControl.swift
+//  UTXOWidget
+//
+//  Created by Prashant Gahlot on 21/12/25.
+//  Copyright © 2025 orgName. All rights reserved.
+//
+
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+struct UTXOWidgetControl: ControlWidget {
+    static let kind: String = "org.androdevlinux.utxo.UTXO.UTXOWidget"
+
+    var body: some ControlWidgetConfiguration {
+        AppIntentControlConfiguration(
+            kind: Self.kind,
+            provider: Provider()
+        ) { value in
+            ControlWidgetToggle(
+                "Start Timer",
+                isOn: value.isRunning,
+                action: StartTimerIntent(value.name)
+            ) { isRunning in
+                Label(isRunning ? "On" : "Off", systemImage: "timer")
+            }
+        }
+        .displayName("Timer")
+        .description("A an example control that runs a timer.")
+    }
+}
+
+extension UTXOWidgetControl {
+    struct Value {
+        var isRunning: Bool
+        var name: String
+    }
+
+    struct Provider: AppIntentControlValueProvider {
+        func previewValue(configuration: TimerConfiguration) -> Value {
+            UTXOWidgetControl.Value(isRunning: false, name: configuration.timerName)
+        }
+
+        func currentValue(configuration: TimerConfiguration) async throws -> Value {
+            let isRunning = true // Check if the timer is running
+            return UTXOWidgetControl.Value(isRunning: isRunning, name: configuration.timerName)
+        }
+    }
+}
+
+struct TimerConfiguration: ControlConfigurationIntent {
+    static let title: LocalizedStringResource = "Timer Name Configuration"
+
+    @Parameter(title: "Timer Name", default: "Timer")
+    var timerName: String
+}
+
+struct StartTimerIntent: SetValueIntent {
+    static let title: LocalizedStringResource = "Start a timer"
+
+    @Parameter(title: "Timer Name")
+    var name: String
+
+    @Parameter(title: "Timer is running")
+    var value: Bool
+
+    init() {}
+
+    init(_ name: String) {
+        self.name = name
+    }
+
+    func perform() async throws -> some IntentResult {
+        // Start the timer…
+        return .result()
+    }
+}

--- a/iosApp/UTXOWidget/UTXOWidgetLiveActivity.swift
+++ b/iosApp/UTXOWidget/UTXOWidgetLiveActivity.swift
@@ -1,0 +1,81 @@
+//
+//  UTXOWidgetLiveActivity.swift
+//  UTXOWidget
+//
+//  Created by Prashant Gahlot on 21/12/25.
+//  Copyright © 2025 orgName. All rights reserved.
+//
+
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+struct UTXOWidgetAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        // Dynamic stateful properties about your activity go here!
+        var emoji: String
+    }
+
+    // Fixed non-changing properties about your activity go here!
+    var name: String
+}
+
+struct UTXOWidgetLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: UTXOWidgetAttributes.self) { context in
+            // Lock screen/banner UI goes here
+            VStack {
+                Text("Hello \(context.state.emoji)")
+            }
+            .activityBackgroundTint(Color.cyan)
+            .activitySystemActionForegroundColor(Color.black)
+
+        } dynamicIsland: { context in
+            DynamicIsland {
+                // Expanded UI goes here.  Compose the expanded UI through
+                // various regions, like leading/trailing/center/bottom
+                DynamicIslandExpandedRegion(.leading) {
+                    Text("Leading")
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text("Trailing")
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text("Bottom \(context.state.emoji)")
+                    // more content
+                }
+            } compactLeading: {
+                Text("L")
+            } compactTrailing: {
+                Text("T \(context.state.emoji)")
+            } minimal: {
+                Text(context.state.emoji)
+            }
+            .widgetURL(URL(string: "http://www.apple.com"))
+            .keylineTint(Color.red)
+        }
+    }
+}
+
+extension UTXOWidgetAttributes {
+    fileprivate static var preview: UTXOWidgetAttributes {
+        UTXOWidgetAttributes(name: "World")
+    }
+}
+
+extension UTXOWidgetAttributes.ContentState {
+    fileprivate static var smiley: UTXOWidgetAttributes.ContentState {
+        UTXOWidgetAttributes.ContentState(emoji: "😀")
+     }
+     
+     fileprivate static var starEyes: UTXOWidgetAttributes.ContentState {
+         UTXOWidgetAttributes.ContentState(emoji: "🤩")
+     }
+}
+
+#Preview("Notification", as: .content, using: UTXOWidgetAttributes.preview) {
+   UTXOWidgetLiveActivity()
+} contentStates: {
+    UTXOWidgetAttributes.ContentState.smiley
+    UTXOWidgetAttributes.ContentState.starEyes
+}

--- a/iosApp/UTXOWidget/WidgetDataHelper.swift
+++ b/iosApp/UTXOWidget/WidgetDataHelper.swift
@@ -1,0 +1,382 @@
+import Foundation
+
+struct WidgetDataHelper {
+    // MARK: - Settings
+    
+    struct Settings: Codable {
+        let appTheme: String?
+        let favPairs: [String]
+        let selectedTradingPair: String
+        let enabledRssProviders: [String]?
+        
+        enum CodingKeys: String, CodingKey {
+            case appTheme
+            case favPairs
+            case selectedTradingPair
+            case enabledRssProviders
+        }
+        
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            appTheme = try container.decodeIfPresent(String.self, forKey: .appTheme)
+            favPairs = try container.decodeIfPresent([String].self, forKey: .favPairs) ?? []
+            selectedTradingPair = try container.decodeIfPresent(String.self, forKey: .selectedTradingPair) ?? "BTC"
+            enabledRssProviders = try container.decodeIfPresent([String].self, forKey: .enabledRssProviders)
+        }
+        
+        init(appTheme: String?, favPairs: [String], selectedTradingPair: String, enabledRssProviders: [String]?) {
+            self.appTheme = appTheme
+            self.favPairs = favPairs
+            self.selectedTradingPair = selectedTradingPair
+            self.enabledRssProviders = enabledRssProviders
+        }
+    }
+    
+    static func readSettings() throws -> Settings {
+        // Widget extensions run in a separate process and can't directly access the main app's cache directory.
+        // We need to use App Groups for shared storage.
+        
+        // Method 1: Try UserDefaults with App Group FIRST (primary method for widget sharing)
+        // The main app syncs favorites here when settings change
+        let appGroupId = "group.org.androdevlinux.utxo"
+        print("🔵 WidgetDataHelper: ========== START readSettings() ==========")
+        print("🔵 WidgetDataHelper: Attempting to read from App Group UserDefaults...")
+        print("🔵 WidgetDataHelper: App Group ID: \(appGroupId)")
+        print("🔵 WidgetDataHelper: Widget bundle ID: \(Bundle.main.bundleIdentifier ?? "unknown")")
+        
+        // Try to get shared UserDefaults
+        let sharedDefaults = UserDefaults(suiteName: appGroupId)
+        print("🔵 WidgetDataHelper: UserDefaults(suiteName:) result: \(sharedDefaults != nil ? "✅ SUCCESS" : "❌ FAILED")")
+        
+        if let sharedDefaults = sharedDefaults {
+            // Force synchronize to ensure we have latest data
+            sharedDefaults.synchronize()
+            print("🔵 WidgetDataHelper: Synchronized UserDefaults")
+            print("🔵 WidgetDataHelper: ✅ App Group UserDefaults available")
+            
+            // Print all keys for debugging
+            let allKeys = sharedDefaults.dictionaryRepresentation().keys
+            print("🔵 WidgetDataHelper: All UserDefaults keys: \(Array(allKeys))")
+            print("🔵 WidgetDataHelper: Total keys count: \(allKeys.count)")
+            
+            // Check if favPairs key exists (as any type)
+            let favPairsValue = sharedDefaults.object(forKey: "favPairs")
+            print("🔵 WidgetDataHelper: favPairs value (any type): \(favPairsValue != nil ? "EXISTS" : "NIL")")
+            if let favPairsValue = favPairsValue {
+                print("🔵 WidgetDataHelper: favPairs value type: \(type(of: favPairsValue))")
+                print("🔵 WidgetDataHelper: favPairs value description: \(String(describing: favPairsValue))")
+                
+                // Try to convert to string if it's not already
+                if let stringValue = favPairsValue as? String {
+                    print("🔵 WidgetDataHelper: favPairs is String: \(stringValue)")
+                } else if let dataValue = favPairsValue as? Data {
+                    print("🔵 WidgetDataHelper: favPairs is Data, size: \(dataValue.count) bytes")
+                    if let stringFromData = String(data: dataValue, encoding: .utf8) {
+                        print("🔵 WidgetDataHelper: Converted Data to String: \(stringFromData)")
+                    }
+                }
+            }
+            
+            // Try multiple ways to read the value
+            var favPairsJson: String? = nil
+            
+            // Method 1: Try as string directly
+            if let stringValue = sharedDefaults.string(forKey: "favPairs") {
+                favPairsJson = stringValue
+                print("🔵 WidgetDataHelper: ✅ Read favPairs as string: \(stringValue)")
+            }
+            
+            // Method 2: Try reading as object and converting
+            if favPairsJson == nil, let objectValue = sharedDefaults.object(forKey: "favPairs") {
+                if let stringValue = objectValue as? String {
+                    favPairsJson = stringValue
+                    print("🔵 WidgetDataHelper: ✅ Read favPairs from object as string: \(stringValue)")
+                } else if let dataValue = objectValue as? Data,
+                          let stringFromData = String(data: dataValue, encoding: .utf8) {
+                    favPairsJson = stringFromData
+                    print("🔵 WidgetDataHelper: ✅ Read favPairs from object as Data, converted: \(stringFromData)")
+                }
+            }
+            
+            if let favPairsJson = favPairsJson {
+                print("🔵 WidgetDataHelper: ✅ Found favPairs JSON string: \(favPairsJson)")
+                print("🔵 WidgetDataHelper: JSON string length: \(favPairsJson.count)")
+                
+                if let favPairsData = favPairsJson.data(using: .utf8) {
+                    print("🔵 WidgetDataHelper: ✅ Converted JSON string to Data, size: \(favPairsData.count) bytes")
+                    
+                    do {
+                        let favPairs = try JSONDecoder().decode([String].self, from: favPairsData)
+                        print("🔵 WidgetDataHelper: ✅ Successfully decoded favorites: \(favPairs)")
+                        print("🔵 WidgetDataHelper: Favorites count: \(favPairs.count)")
+                        
+                        // Found favorites in UserDefaults
+                        let selectedTradingPair = sharedDefaults.string(forKey: "selectedTradingPair") ?? "BTC"
+                        let appTheme = sharedDefaults.string(forKey: "appTheme")
+                        print("🔵 WidgetDataHelper: ✅ Returning Settings with \(favPairs.count) favorites")
+                        
+                        return Settings(
+                            appTheme: appTheme,
+                            favPairs: favPairs,
+                            selectedTradingPair: selectedTradingPair,
+                            enabledRssProviders: nil
+                        )
+                    } catch {
+                        print("🔵 WidgetDataHelper: ❌ Failed to decode favPairs JSON: \(error)")
+                        print("🔵 WidgetDataHelper: Error details: \(error.localizedDescription)")
+                        if let jsonString = String(data: favPairsData, encoding: .utf8) {
+                            print("🔵 WidgetDataHelper: Attempted to decode: \(jsonString)")
+                        }
+                    }
+                } else {
+                    print("🔵 WidgetDataHelper: ❌ Failed to convert JSON string to Data")
+                }
+            } else {
+                print("🔵 WidgetDataHelper: ❌ Could not read favPairs as string from UserDefaults")
+                print("🔵 WidgetDataHelper: Available keys: \(Array(allKeys))")
+                print("🔵 WidgetDataHelper: Checking each key individually...")
+                
+                // Debug: Try reading each key
+                for key in allKeys {
+                    if let value = sharedDefaults.object(forKey: key) {
+                        print("🔵 WidgetDataHelper: Key '\(key)': type=\(type(of: value)), value=\(value)")
+                    }
+                }
+            }
+        } else {
+            print("🔵 WidgetDataHelper: ❌ App Group UserDefaults not available - App Groups may not be configured")
+            print("🔵 WidgetDataHelper: Make sure App Groups capability is added to both app and widget targets")
+            print("🔵 WidgetDataHelper: App Group ID: group.org.androdevlinux.utxo")
+        }
+        
+        // Method 2: Fall back to App Group file container (if configured)
+        var settingsFile: URL?
+        var triedPaths: [String] = []
+        
+        if let appGroupURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.org.androdevlinux.utxo") {
+            let appGroupSettingsFile = appGroupURL.appendingPathComponent("settings.json")
+            triedPaths.append(appGroupSettingsFile.path)
+            if FileManager.default.fileExists(atPath: appGroupSettingsFile.path) {
+                settingsFile = appGroupSettingsFile
+            }
+        }
+        
+        // Method 3: Fall back to widget's own cache directory (won't have main app's data)
+        if settingsFile == nil {
+            if let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first {
+                let cacheSettingsFile = cacheDir.appendingPathComponent("settings.json")
+                triedPaths.append(cacheSettingsFile.path)
+                if FileManager.default.fileExists(atPath: cacheSettingsFile.path) {
+                    settingsFile = cacheSettingsFile
+                }
+            }
+        }
+        
+        guard let settingsFile = settingsFile else {
+            // Debug: Log tried paths
+            print("🔵 WidgetDataHelper: Settings file not found. Tried paths: \(triedPaths)")
+            print("🔵 WidgetDataHelper: Returning empty Settings (no UserDefaults, no file)")
+            print("🔵 WidgetDataHelper: ========== END readSettings() - RETURNING EMPTY ==========")
+            return Settings(appTheme: "System", favPairs: [], selectedTradingPair: "BTC", enabledRssProviders: nil)
+        }
+        
+        do {
+            let data = try Data(contentsOf: settingsFile)
+            
+            // Debug: Print raw JSON
+            if let jsonString = String(data: data, encoding: .utf8) {
+                print("WidgetDataHelper: Found settings file at \(settingsFile.path)")
+                print("WidgetDataHelper: Settings JSON (first 500 chars): \(String(jsonString.prefix(500)))")
+            }
+            
+            let decoder = JSONDecoder()
+            let settings = try decoder.decode(Settings.self, from: data)
+            
+            // Debug: Print decoded settings
+            print("WidgetDataHelper: Decoded favPairs count: \(settings.favPairs.count)")
+            print("WidgetDataHelper: Decoded favPairs: \(settings.favPairs)")
+            let filtered = settings.favPairs.filter { !$0.isEmpty && !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+            print("WidgetDataHelper: Filtered favPairs count: \(filtered.count)")
+            print("WidgetDataHelper: Filtered favPairs: \(filtered)")
+            
+            return settings
+        } catch {
+            print("WidgetDataHelper: Failed to decode settings: \(error)")
+            // Try to read as string to see what we got
+            if let data = try? Data(contentsOf: settingsFile),
+               let jsonString = String(data: data, encoding: .utf8) {
+                print("WidgetDataHelper: Raw JSON content (first 500 chars): \(String(jsonString.prefix(500)))")
+            }
+            throw error
+        }
+    }
+    
+    // MARK: - Ticker Data
+    
+    struct TickerData: Codable {
+        let symbol: String
+        let lastPrice: String
+        let priceChangePercent: String
+        let quoteVolume: String
+    }
+    
+    static func fetchTicker(symbol: String) async -> TickerData? {
+        guard let url = URL(string: "https://api.binance.com/api/v3/ticker/24hr?symbol=\(symbol)") else {
+            return nil
+        }
+        
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+            
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                return nil
+            }
+            
+            // Check if response is an error
+            if let responseString = String(data: data, encoding: .utf8),
+               responseString.contains("\"code\"") && responseString.contains("\"msg\"") {
+                return nil
+            }
+            
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            let ticker24hr = try decoder.decode(Ticker24hrResponse.self, from: data)
+            
+            return TickerData(
+                symbol: ticker24hr.symbol,
+                lastPrice: ticker24hr.lastPrice,
+                priceChangePercent: ticker24hr.priceChangePercent,
+                quoteVolume: ticker24hr.quoteVolume
+            )
+        } catch {
+            return nil
+        }
+    }
+    
+    private struct Ticker24hrResponse: Codable {
+        let symbol: String
+        let lastPrice: String
+        let priceChangePercent: String
+        let quoteVolume: String
+    }
+    
+    // MARK: - Chart Data
+    
+    static func fetchChartData(symbol: String) async -> [Double] {
+        guard let url = URL(string: "https://api.binance.com/api/v3/uiKlines?symbol=\(symbol)&interval=1s&limit=1000") else {
+            return []
+        }
+        
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            
+            guard let jsonArray = try JSONSerialization.jsonObject(with: data) as? [[Any]] else {
+                return []
+            }
+            
+            // Extract close prices (index 4 in the kline array)
+            return jsonArray.compactMap { kline in
+                guard kline.count > 4,
+                      let closePriceString = kline[4] as? String,
+                      let closePrice = Double(closePriceString) else {
+                    return nil
+                }
+                return closePrice
+            }
+        } catch {
+            return []
+        }
+    }
+    
+    // MARK: - Formatting Helpers
+    
+    static func extractSymbolParts(symbol: String, tradingPair: String) -> (String, String) {
+        let quoteCurrencies = ["USDT", "USDC", "BUSD", "FDUSD", "BTC", "ETH", "BNB", "DAI", "TUSD", "EUR", "GBP", "JPY"]
+        
+        // First try with selected trading pair
+        if symbol.uppercased().hasSuffix(tradingPair.uppercased()) && symbol.count > tradingPair.count {
+            let base = String(symbol.prefix(symbol.count - tradingPair.count))
+            if !base.isEmpty {
+                return (base, tradingPair)
+            }
+        }
+        
+        // Fallback: try to extract from symbol using common quote currencies
+        for quote in quoteCurrencies.sorted(by: { $0.count > $1.count }) {
+            if symbol.uppercased().hasSuffix(quote.uppercased()) && symbol.count > quote.count {
+                let base = String(symbol.prefix(symbol.count - quote.count))
+                if !base.isEmpty {
+                    return (base, quote)
+                }
+            }
+        }
+        
+        // Last resort: return symbol as-is
+        return (symbol, "")
+    }
+    
+    static func formatPrice(_ price: String, quoteSymbol: String) -> String {
+        guard let priceValue = Double(price) else {
+            return price
+        }
+        
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 8
+        
+        if priceValue >= 1000 {
+            formatter.maximumFractionDigits = 0
+        } else if priceValue >= 1 {
+            formatter.maximumFractionDigits = 2
+        } else if priceValue >= 0.01 {
+            formatter.maximumFractionDigits = 4
+        } else {
+            formatter.maximumFractionDigits = 8
+        }
+        
+        let formattedPrice = formatter.string(from: NSNumber(value: priceValue)) ?? price
+        
+        if !quoteSymbol.isEmpty {
+            return "\(formattedPrice) \(quoteSymbol)"
+        } else {
+            return formattedPrice
+        }
+    }
+    
+    static func formatVolume(_ volume: String) -> String {
+        guard let value = Double(volume) else {
+            return volume
+        }
+        
+        if value >= 1_000_000_000 {
+            let billions = value / 1_000_000_000
+            if billions >= 100 {
+                return "\(Int(billions))B"
+            } else if billions >= 10 {
+                return String(format: "%.1fB", billions)
+            } else {
+                return String(format: "%.2fB", billions)
+            }
+        } else if value >= 1_000_000 {
+            let millions = value / 1_000_000
+            if millions >= 100 {
+                return "\(Int(millions))M"
+            } else if millions >= 10 {
+                return String(format: "%.1fM", millions)
+            } else {
+                return String(format: "%.2fM", millions)
+            }
+        } else if value >= 1_000 {
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+            formatter.maximumFractionDigits = 0
+            return formatter.string(from: NSNumber(value: value)) ?? volume
+        } else if value >= 1 {
+            return String(format: "%.2f", value)
+        } else {
+            return String(format: "%.4f", value)
+        }
+    }
+}
+

--- a/iosApp/UTXOWidgetExtension.entitlements
+++ b/iosApp/UTXOWidgetExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.org.androdevlinux.utxo</string>
+	</array>
+</dict>
+</plist>

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -11,7 +11,34 @@
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
+		D65EDBB62EF76C8C00267519 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D65EDBB52EF76C8C00267519 /* WidgetKit.framework */; };
+		D65EDBB82EF76C8C00267519 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D65EDBB72EF76C8C00267519 /* SwiftUI.framework */; };
+		D65EDBC92EF76C8D00267519 /* UTXOWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = D65EDBB42EF76C8C00267519 /* UTXOWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		D65EDBC72EF76C8D00267519 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7555FF73242A565900829871 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D65EDBB32EF76C8C00267519;
+			remoteInfo = UTXOWidgetExtension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		D65EDBCA2EF76C8D00267519 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				D65EDBC92EF76C8D00267519 /* UTXOWidgetExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		058557BA273AAA24004C7B11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -21,13 +48,41 @@
 		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		D65EDBB42EF76C8C00267519 /* UTXOWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = UTXOWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		D65EDBB52EF76C8C00267519 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		D65EDBB72EF76C8C00267519 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		D65EDBDD2EF771F700267519 /* UTXOWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = UTXOWidgetExtension.entitlements; sourceTree = "<group>"; };
+		D65EDBDE2EF7725600267519 /* iosApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = iosApp.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		D65EDBCD2EF76C8D00267519 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = D65EDBB32EF76C8C00267519 /* UTXOWidgetExtension */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		D65EDBB92EF76C8C00267519 /* UTXOWidget */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (D65EDBCD2EF76C8D00267519 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = UTXOWidget; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		B92378962B6B1156000C7307 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D65EDBB12EF76C8C00267519 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D65EDBB82EF76C8C00267519 /* SwiftUI.framework in Frameworks */,
+				D65EDBB62EF76C8C00267519 /* WidgetKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -45,6 +100,8 @@
 		42799AB246E5F90AF97AA0EF /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D65EDBB52EF76C8C00267519 /* WidgetKit.framework */,
+				D65EDBB72EF76C8C00267519 /* SwiftUI.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -52,8 +109,10 @@
 		7555FF72242A565900829871 = {
 			isa = PBXGroup;
 			children = (
+				D65EDBDD2EF771F700267519 /* UTXOWidgetExtension.entitlements */,
 				AB1DB47929225F7C00F7AF9C /* Configuration */,
 				7555FF7D242A565900829871 /* iosApp */,
+				D65EDBB92EF76C8C00267519 /* UTXOWidget */,
 				7555FF7C242A565900829871 /* Products */,
 				42799AB246E5F90AF97AA0EF /* Frameworks */,
 			);
@@ -63,6 +122,7 @@
 			isa = PBXGroup;
 			children = (
 				7555FF7B242A565900829871 /* UTXO.app */,
+				D65EDBB42EF76C8C00267519 /* UTXOWidgetExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -70,6 +130,7 @@
 		7555FF7D242A565900829871 /* iosApp */ = {
 			isa = PBXGroup;
 			children = (
+				D65EDBDE2EF7725600267519 /* iosApp.entitlements */,
 				058557BA273AAA24004C7B11 /* Assets.xcassets */,
 				7555FF82242A565900829871 /* ContentView.swift */,
 				7555FF8C242A565B00829871 /* Info.plist */,
@@ -98,10 +159,12 @@
 				7555FF77242A565900829871 /* Sources */,
 				B92378962B6B1156000C7307 /* Frameworks */,
 				7555FF79242A565900829871 /* Resources */,
+				D65EDBCA2EF76C8D00267519 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				D65EDBC82EF76C8D00267519 /* PBXTargetDependency */,
 			);
 			name = iosApp;
 			packageProductDependencies = (
@@ -110,6 +173,28 @@
 			productReference = 7555FF7B242A565900829871 /* UTXO.app */;
 			productType = "com.apple.product-type.application";
 		};
+		D65EDBB32EF76C8C00267519 /* UTXOWidgetExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D65EDBCE2EF76C8D00267519 /* Build configuration list for PBXNativeTarget "UTXOWidgetExtension" */;
+			buildPhases = (
+				D65EDBB02EF76C8C00267519 /* Sources */,
+				D65EDBB12EF76C8C00267519 /* Frameworks */,
+				D65EDBB22EF76C8C00267519 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				D65EDBB92EF76C8C00267519 /* UTXOWidget */,
+			);
+			name = UTXOWidgetExtension;
+			packageProductDependencies = (
+			);
+			productName = UTXOWidgetExtension;
+			productReference = D65EDBB42EF76C8C00267519 /* UTXOWidgetExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -117,12 +202,15 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastSwiftUpdateCheck = 1130;
+				LastSwiftUpdateCheck = 2620;
 				LastUpgradeCheck = 1540;
 				ORGANIZATIONNAME = orgName;
 				TargetAttributes = {
 					7555FF7A242A565900829871 = {
 						CreatedOnToolsVersion = 11.3.1;
+					};
+					D65EDBB32EF76C8C00267519 = {
+						CreatedOnToolsVersion = 26.2;
 					};
 				};
 			};
@@ -142,6 +230,7 @@
 			projectRoot = "";
 			targets = (
 				7555FF7A242A565900829871 /* iosApp */,
+				D65EDBB32EF76C8C00267519 /* UTXOWidgetExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -153,6 +242,13 @@
 			files = (
 				058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */,
 				058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D65EDBB22EF76C8C00267519 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -189,7 +285,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D65EDBB02EF76C8C00267519 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		D65EDBC82EF76C8D00267519 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D65EDBB32EF76C8C00267519 /* UTXOWidgetExtension */;
+			targetProxy = D65EDBC72EF76C8D00267519 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		7555FFA3242A565B00829871 /* Debug */ = {
@@ -317,6 +428,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 28;
@@ -350,6 +462,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 28;
@@ -378,6 +491,84 @@
 			};
 			name = Release;
 		};
+		D65EDBCB2EF76C8D00267519 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = UTXOWidgetExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 37UYJHD27F;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = UTXOWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = UTXOWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 orgName. All rights reserved.";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.androdevlinux.utxo.UTXO.UTXOWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D65EDBCC2EF76C8D00267519 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = UTXOWidgetExtension.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 37UYJHD27F;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = UTXOWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = UTXOWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2025 orgName. All rights reserved.";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.androdevlinux.utxo.UTXO.UTXOWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -395,6 +586,15 @@
 			buildConfigurations = (
 				7555FFA6242A565B00829871 /* Debug */,
 				7555FFA7242A565B00829871 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D65EDBCE2EF76C8D00267519 /* Build configuration list for PBXNativeTarget "UTXOWidgetExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D65EDBCB2EF76C8D00267519 /* Debug */,
+				D65EDBCC2EF76C8D00267519 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -46,5 +46,14 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>utxo</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/iosApp/iosApp/SettingsSyncHelper.swift
+++ b/iosApp/iosApp/SettingsSyncHelper.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Helper to sync settings to App Group for widget access
+class SettingsSyncHelper {
+    static let appGroupIdentifier = "group.org.androdevlinux.utxo"
+    
+    /// Sync settings file to App Group container
+    /// Call this whenever settings are updated in the app
+    static func syncSettingsToAppGroup() {
+        guard let appGroupURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier) else {
+            print("SettingsSyncHelper: App Group not configured: \(appGroupIdentifier)")
+            return
+        }
+        
+        // Get the main app's cache directory
+        guard let cacheDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            print("SettingsSyncHelper: Could not find cache directory")
+            return
+        }
+        
+        let sourceFile = cacheDir.appendingPathComponent("settings.json")
+        let destinationFile = appGroupURL.appendingPathComponent("settings.json")
+        
+        // Check if source file exists
+        guard FileManager.default.fileExists(atPath: sourceFile.path) else {
+            print("SettingsSyncHelper: Source settings file does not exist at \(sourceFile.path)")
+            return
+        }
+        
+        do {
+            // Copy settings file to App Group container
+            try FileManager.default.copyItem(at: sourceFile, to: destinationFile)
+            print("SettingsSyncHelper: Successfully synced settings to App Group at \(destinationFile.path)")
+        } catch {
+            // If file exists, try removing and copying again
+            if FileManager.default.fileExists(atPath: destinationFile.path) {
+                do {
+                    try FileManager.default.removeItem(at: destinationFile)
+                    try FileManager.default.copyItem(at: sourceFile, to: destinationFile)
+                    print("SettingsSyncHelper: Successfully updated settings in App Group")
+                } catch {
+                    print("SettingsSyncHelper: Failed to update settings in App Group: \(error)")
+                }
+            } else {
+                print("SettingsSyncHelper: Failed to copy settings to App Group: \(error)")
+            }
+        }
+    }
+    
+    /// Sync favorites to UserDefaults (simpler alternative)
+    static func syncFavoritesToUserDefaults(favPairs: [String], selectedTradingPair: String, appTheme: String?) {
+        guard let sharedDefaults = UserDefaults(suiteName: appGroupIdentifier) else {
+            print("SettingsSyncHelper: App Group UserDefaults not available")
+            return
+        }
+        
+        if let favPairsData = try? JSONEncoder().encode(favPairs) {
+            sharedDefaults.set(favPairsData, forKey: "favPairs")
+            sharedDefaults.set(selectedTradingPair, forKey: "selectedTradingPair")
+            if let appTheme = appTheme {
+                sharedDefaults.set(appTheme, forKey: "appTheme")
+            }
+            sharedDefaults.synchronize()
+            print("SettingsSyncHelper: Synced favorites to UserDefaults: \(favPairs)")
+        }
+    }
+}
+

--- a/iosApp/iosApp/WidgetReloadHelper.swift
+++ b/iosApp/iosApp/WidgetReloadHelper.swift
@@ -1,0 +1,11 @@
+import Foundation
+import WidgetKit
+
+/// Helper to reload widget timeline when favorites change
+/// This is called from Kotlin code via Objective-C interop
+@objc public class WidgetReloadHelper: NSObject {
+    @objc public static func reloadWidgetTimeline() {
+        WidgetCenter.shared.reloadTimelines(ofKind: "UTXOWidget")
+        print("WidgetReloadHelper: ✅ Reloaded widget timeline for UTXOWidget")
+    }
+}

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -1,10 +1,79 @@
 import SwiftUI
+import WidgetKit
 
 @main
 struct iOSApp: App {
+    @StateObject private var urlHandler = URLHandler()
+    private var timer: Timer?
+    
+    init() {
+        // Check UserDefaults flag periodically to reload widget when Kotlin sets it
+        // This is simpler than NSNotification which has API issues in Kotlin/Native
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            let userDefaults = UserDefaults.standard
+            if userDefaults.object(forKey: "WidgetReloadRequested") != nil {
+                // Clear the flag and reload widget
+                userDefaults.removeObject(forKey: "WidgetReloadRequested")
+                userDefaults.synchronize()
+                WidgetCenter.shared.reloadTimelines(ofKind: "UTXOWidget")
+            }
+        }
+    }
+    
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environmentObject(urlHandler)
+                .onOpenURL { url in
+                    urlHandler.handleURL(url)
+                }
         }
+    }
+}
+
+class URLHandler: ObservableObject {
+    func handleURL(_ url: URL) {
+        guard url.scheme == "utxo" else { return }
+        
+        if url.host == "coin" {
+            // Extract symbol from path: utxo://coin/BTCUSDT
+            let symbol = url.pathComponents.last ?? ""
+            let (base, quote) = extractSymbolParts(symbol: symbol, tradingPair: "BTC")
+            let displaySymbol = quote.isEmpty ? symbol : "\(base)/\(quote)"
+            
+            // Store in UserDefaults for Kotlin code to read
+            let userDefaults = UserDefaults.standard
+            userDefaults.set(symbol, forKey: "pendingCoinSymbol")
+            userDefaults.set(displaySymbol, forKey: "pendingCoinDisplaySymbol")
+            userDefaults.synchronize()
+        } else if url.host == "favorites" {
+            // Navigate to favorites - store empty to trigger favorites navigation
+            let userDefaults = UserDefaults.standard
+            userDefaults.set("", forKey: "pendingCoinSymbol")
+            userDefaults.set("", forKey: "pendingCoinDisplaySymbol")
+            userDefaults.synchronize()
+        }
+    }
+    
+    private func extractSymbolParts(symbol: String, tradingPair: String) -> (String, String) {
+        let quoteCurrencies = ["USDT", "USDC", "BUSD", "FDUSD", "BTC", "ETH", "BNB", "DAI", "TUSD", "EUR", "GBP", "JPY"]
+        
+        if symbol.uppercased().hasSuffix(tradingPair.uppercased()) && symbol.count > tradingPair.count {
+            let base = String(symbol.prefix(symbol.count - tradingPair.count))
+            if !base.isEmpty {
+                return (base, tradingPair)
+            }
+        }
+        
+        for quote in quoteCurrencies.sorted(by: { $0.count > $1.count }) {
+            if symbol.uppercased().hasSuffix(quote.uppercased()) && symbol.count > quote.count {
+                let base = String(symbol.prefix(symbol.count - quote.count))
+                if !base.isEmpty {
+                    return (base, quote)
+                }
+            }
+        }
+        
+        return (symbol, "")
     }
 }

--- a/iosApp/iosApp/iosApp.entitlements
+++ b/iosApp/iosApp/iosApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.org.androdevlinux.utxo</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Description
This PR implements a complete iOS Widget Extension that displays favorite cryptocurrencies on the iOS home screen, matching the functionality of the Android widget. The widget shows real-time prices, change percentages, volumes, and sparkline charts for up to 4 favorite coins.

## Changes Made
- **iOS Widget Extension Implementation**:
  - Created UTXOWidget SwiftUI widget with medium and large sizes
  - Implemented FavoritesTimelineProvider for data fetching
  - Added FavoritesWidgetEntryView with sparkline charts
  - Created WidgetDataHelper for API calls and data formatting
  - Implemented RefreshWidgetIntent for manual refresh functionality
  
- **App Integration**:
  - Added App Group UserDefaults sync for widget data sharing
  - Implemented deep linking (utxo://coin/{SYMBOL}) for widget navigation
  - Fixed widget coin detail navigation when app is already running
  - Added lifecycle-based ON_RESUME check for pending coin details
  - Ensured NavHost is ready before navigation to prevent crashes
  
- **Documentation**:
  - Added comprehensive iOS widget documentation in docs/ios/widget/WIDGET_DOCUMENTATION.md
  - Updated README.md with iOS widget features and usage instructions
  - Removed "Android Only" label from widgets section

- **Platform-Specific Updates**:
  - iOS: Added widget extension target configuration
  - iOS: Implemented URL scheme handling for deep linking
  - Common: Enhanced getPendingCoinDetailFromIntent() with lifecycle support

## Type of Change
- [x] New feature
- [x] Bug fix (navigation crash fix)
- [x] Documentation update

## Testing Done
- [x] Manual testing on iOS Simulator
- [x] Manual testing on iOS device
- [x] Verified widget displays favorites correctly
- [x] Tested widget refresh functionality
- [x] Verified deep linking from widget to coin detail screen
- [x] Tested navigation when app is already running
- [x] Tested navigation when app launches from widget click
- [x] Verified theme-aware widget display (light/dark mode)

## Widget Features
- ✅ Displays up to 4 favorites (2 in medium widget, 4 in large widget)
- ✅ Live prices and change percentages with color coding (green/red)
- ✅ Volume display with smart formatting (B, M, K)
- ✅ Sparkline charts for each coin (1000 data points, 1-second intervals)
- ✅ Automatic refresh every 5 minutes (managed by iOS WidgetKit)
- ✅ Manual refresh button (↻ icon in header)
- ✅ Theme-aware (respects system light/dark mode)
- ✅ Deep linking - Tap widget to open app, tap coin to open coin details
- ✅ Empty state message when no favorites are added

## Checklist
- [x] Code follows project style guidelines
- [x] Tests pass locally
- [x] Documentation updated
- [x] No breaking changes
- [x] Reviewed own code

## Related Issues
Closes any issues related to iOS widget implementation

## Additional Notes
- Widget uses App Group UserDefaults (group.org.androdevlinux.utxo) for data sharing
- Deep linking implemented via URL scheme (utxo://coin/{SYMBOL})
- Navigation fix ensures NavHost is ready before attempting navigation
- Lifecycle-based checking prevents missed widget clicks when app is already running
- Widget matches Android widget functionality and design patterns