### PR TITLE
[FIX] Improve NewsService HTTP client for LineageOS compatibility

### DIFF
--- a/composeApp/src/androidMain/kotlin/App.android.kt
+++ b/composeApp/src/androidMain/kotlin/App.android.kt
@@ -9,7 +9,9 @@ import androidx.core.net.toUri
 import io.github.xxfast.kstore.KStore
 import io.github.xxfast.kstore.file.storeOf
 import io.ktor.client.HttpClient
+import io.ktor.client.engine.android.Android
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
@@ -56,13 +58,18 @@ actual fun createNewsHttpClient(): HttpClient {
         isLenient = true
         ignoreUnknownKeys = true
     }
-    return HttpClient(CIO) {
+    return HttpClient(Android) {
         install(Logging) {
             logger = Logger.SIMPLE
             level = LogLevel.NONE
         }
         install(ContentNegotiation) {
             json(json)
+        }
+        install(HttpTimeout) {
+            connectTimeoutMillis = 15_000 // 15 seconds
+            socketTimeoutMillis = 30_000 // 30 seconds (RSS feeds can be large)
+            requestTimeoutMillis = 45_000 // 45 seconds (allow more time for slow LineageOS connections)
         }
     }
 }


### PR DESCRIPTION
## Description
This PR fixes connection timeout issues with the NewsService RSS feed fetching on LineageOS devices. The changes improve network stack compatibility and increase timeout values to accommodate slower connections on custom Android ROMs.

## Changes Made
- Switched HTTP client engine from CIO to Android engine for better compatibility with Android's network stack
- Added HttpTimeout plugin configuration with increased timeout values:
  - Connect timeout: 15 seconds (increased from default)
  - Socket timeout: 30 seconds (RSS feeds can be large)
  - Request timeout: 45 seconds (allows more time for slow LineageOS connections)
- Updated imports to include Android engine and HttpTimeout plugin

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance improvement

## Testing Done
- [x] Manual testing on Android (LineageOS devices)
- [ ] Unit tests added/updated
- [ ] Manual testing on iOS
- [ ] Manual testing on Desktop

## Technical Details
The Android engine uses OkHttp under the hood, which better respects Android's network configurations and system-level network policies. This is particularly important for custom ROMs like LineageOS that may have stricter network policies or different DNS resolution behavior.

The increased timeout values ensure that:
1. Connections have sufficient time to establish on slower networks
2. Large RSS feed downloads don't timeout prematurely
3. The overall request has enough time to complete on devices with network constraints

## Related Issues
Fixes timeout exceptions on LineageOS devices where RSS feed requests were failing with `ConnectTimeoutException` and `HttpRequestTimeoutException`.

## Additional Notes
- This change is Android-specific and doesn't affect other platforms
- The timeout values are conservative but necessary for LineageOS compatibility
- Future improvements could include adaptive timeout based on network conditions