### PR TITLE
[FEATURE] Add iOS lockscreen widget with chart and readable text

### DIFF
--- a/iosApp/UTXOWidget/UTXOWidget.swift
+++ b/iosApp/UTXOWidget/UTXOWidget.swift
@@ -15,12 +15,10 @@ struct UTXOWidget: Widget {
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: kind, provider: FavoritesTimelineProvider()) { entry in
             FavoritesWidgetEntryView(entry: entry)
-                .containerBackground(.fill.tertiary, for: .widget)
-                .padding(.horizontal, 0)
         }
         .configurationDisplayName("Favorites")
         .description("Display your favorite cryptocurrencies with live prices and charts.")
-        .supportedFamilies([.systemMedium, .systemLarge])
+        .supportedFamilies([.systemMedium, .systemLarge, .accessoryRectangular])
     }
 }
 
@@ -243,6 +241,21 @@ struct FavoritesTimelineProvider: TimelineProvider {
         favorites: [
             .init(id: "1", symbol: "BTCUSDT", baseSymbol: "BTC", quoteSymbol: "USDT", price: "50,000 USDT", changePercent: 2.5, volume: "1.2B", chartData: []),
             .init(id: "2", symbol: "ETHUSDT", baseSymbol: "ETH", quoteSymbol: "USDT", price: "3,000 USDT", changePercent: -1.2, volume: "800M", chartData: [])
+        ],
+        isLoading: false,
+        isRefreshing: false,
+        errorMessage: nil,
+        rotationAngle: 0
+    )
+}
+
+#Preview(as: .accessoryRectangular) {
+    UTXOWidget()
+} timeline: {
+    FavoritesWidgetEntry(
+        date: Date(),
+        favorites: [
+            .init(id: "1", symbol: "BTCUSDT", baseSymbol: "BTC", quoteSymbol: "USDT", price: "50,000 USDT", changePercent: 2.5, volume: "1.2B", chartData: [])
         ],
         isLoading: false,
         isRefreshing: false,


### PR DESCRIPTION
## Description
This PR adds lockscreen widget support to the iOS UTXO widget, allowing users to view their favorite cryptocurrency price and trend directly on their iPhone lockscreen. The widget displays a compact, readable view with a sparkline chart showing price trends.

## Changes Made
- Added `.accessoryRectangular` widget family support to UTXOWidget configuration
- Created new `LockscreenWidgetView` component optimized for lockscreen display
- Implemented compact layout showing:
  - Left: Cryptocurrency symbol (base/quote) with readable text sizes
  - Center: Small sparkline chart (40x18) showing price trend
  - Right: Current price and change percentage with color-coded arrow icon
- Fixed text truncation issues with proper layout constraints (`fixedSize`, `minimumScaleFactor`)
- Optimized text sizes for lockscreen readability:
  - Symbol: 16pt bold
  - Price: 15pt semibold
  - Change: 12pt semibold
- Added support for `containerBackground` for iOS 17+ lockscreen widgets
- Widget automatically refreshes every 5 minutes
- Added error handling and empty state views for lockscreen widget

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance improvement

## Testing Done
- [x] Manual testing on iOS lockscreen widget
- [x] Verified text readability and truncation handling
- [x] Tested chart rendering with various data sets
- [x] Verified widget refresh behavior
- [x] Tested error states and empty states

## Files Changed
- `iosApp/UTXOWidget/FavoritesWidgetEntryView.swift` - Added LockscreenWidgetView component
- `iosApp/UTXOWidget/UTXOWidget.swift` - Added .accessoryRectangular to supported families

## Screenshots/Videos
The lockscreen widget displays:
- Left: Symbol (BTC/USDT) with readable text
- Center: Small sparkline chart showing price trend
- Right: Price and change percentage with color-coded arrow icon

## Checklist
- [x] Code follows project style guidelines
- [x] Tests pass locally
- [x] Documentation updated (if needed)
- [x] No breaking changes
- [x] Reviewed own code

## Related Issues
N/A

## Additional Notes
- The lockscreen widget shows only the first favorite cryptocurrency to keep the display compact
- Chart data is fetched from the same API as the home screen widget
- Text sizes are optimized for lockscreen readability while maintaining compact layout
- The widget uses the same refresh mechanism as other widget sizes (5-minute intervals)
- Container background support ensures proper appearance on iOS 17+ lockscreen widgets