### PR TITLE
Feat/binance style order book

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "org.androdevlinux.utxo"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 33
-        versionName = "0.3.3"
+        versionCode = 36
+        versionName = "0.3.6"
     }
     
     compileOptions {

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -25,7 +25,7 @@
     <string name="settings_use_dark_theme">Use dark theme</string>
     <string name="settings_about">About</string>
     <string name="settings_version">Version</string>
-    <string name="settings_version_number">0.3.3</string>
+    <string name="settings_version_number">0.3.6</string>
     <string name="settings_privacy_policy">Privacy Policy</string>
     <string name="settings_website">Website</string>
     <string name="settings_github">Github</string>

--- a/composeApp/src/commonMain/kotlin/ktx/DoubleKtx.kt
+++ b/composeApp/src/commonMain/kotlin/ktx/DoubleKtx.kt
@@ -5,7 +5,7 @@ import kotlin.math.roundToInt
 
 fun Double.formatAsCurrency(): String {
     val absValue = this.absoluteValue
-    val integerPart = absValue.toInt()
+    val integerPart = absValue.toLong()
     val fractionalPart = ((absValue - integerPart) * 100).roundToInt()
 
     val formattedInteger = integerPart.toString().reversed().chunked(3).joinToString(",").reversed()

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -431,7 +431,7 @@
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 36;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = 37UYJHD27F;
 				ENABLE_PREVIEWS = YES;
@@ -447,7 +447,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.3;
+				MARKETING_VERSION = 0.3.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = org.androdevlinux.utxo.UTXO;
 				PRODUCT_NAME = "${APP_NAME}";
@@ -465,7 +465,7 @@
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 33;
+				CURRENT_PROJECT_VERSION = 36;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = 37UYJHD27F;
 				ENABLE_PREVIEWS = YES;
@@ -481,7 +481,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.3;
+				MARKETING_VERSION = 0.3.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = org.androdevlinux.utxo.UTXO;
 				PRODUCT_NAME = "${APP_NAME}";


### PR DESCRIPTION
feat(ui): implement Binance-style order book with price grouping
Refactor OrderBookHeatMap to match Binance's order book UI:

- Add dynamic price grouping dropdown with symbol-specific options
  (e.g., BTC shows 0.01, 0.1, 1, 10, 50, 100, 1000)
- Implement actual price aggregation logic that groups orders by
  price buckets and sums quantities
- Fix depth bar direction: bars now grow OUTWARD from center
  (where bid/ask prices meet)
- Color prices like Binance: green (#0ECB81) for bids,
  red (#F6465D) for asks
- Fix integer overflow in formatAsCurrency by using toLong()
  instead of toInt() for large price values
- Clean up unused imports and parameters