### PR TITLE
[CHORE] Add Android release signing configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ captures
 !*.xcworkspace/contents.xcworkspacedata
 **/xcshareddata/WorkspaceSettings.xcsettings
 kotlin-js-store/
+keystore.properties
+*.jks

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,3 +1,7 @@
+import com.android.build.api.dsl.ApplicationExtension
+import java.io.File
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.jetbrainsCompose)
@@ -14,6 +18,27 @@ android {
         targetSdk = libs.versions.android.targetSdk.get().toInt()
         versionCode = 40
         versionName = "0.4.0"
+    }
+
+    val keystorePropsFile = rootProject.file("keystore.properties")
+    val keystoreProps = Properties().apply {
+        if (keystorePropsFile.exists()) load(keystorePropsFile.inputStream())
+    }
+
+
+    signingConfigs {
+        create("release") {
+            storeFile = file(
+                System.getenv("KEYSTORE_FILE")
+                    ?: keystoreProps.getProperty("storeFile", "")
+            )
+            storePassword = System.getenv("KEYSTORE_PASSWORD")
+                ?: keystoreProps.getProperty("storePassword", "")
+            keyAlias = System.getenv("KEY_ALIAS")
+                ?: keystoreProps.getProperty("keyAlias", "")
+            keyPassword = System.getenv("KEY_PASSWORD")
+                ?: keystoreProps.getProperty("keyPassword", "")
+        }
     }
     
     compileOptions {
@@ -44,6 +69,7 @@ android {
         release {
             isMinifyEnabled = true
             isShrinkResources = true
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "../composeApp/proguard-rules.pro")
         }
     }


### PR DESCRIPTION
## Description
Adds release signing configuration to the Android app so release builds can be signed locally via `keystore.properties` or in CI via environment variables. Also adds gitignore entries to prevent accidental commits of keystore secrets.

## Changes Made
- **androidApp/build.gradle.kts** — Added `signingConfigs.release` block that reads keystore credentials from environment variables (CI) with fallback to `keystore.properties` (local). Wired the `release` build type to use this signing config.
- **.gitignore** — Added `keystore.properties` and `*.jks` to prevent secrets from being committed.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance improvement

## Testing Done
- [x] Verified `keystore.properties` and `*.jks` are ignored by git
- [ ] Manual testing on Android (release build signing)

## Checklist
- [x] Code follows project style guidelines
- [x] No secrets committed to the repository
- [x] No breaking changes

## Related Issues
N/A

Made with [Cursor](https://cursor.com)