### PR TITLE
[FIX] Guard signing config against empty keystore path

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -26,12 +26,14 @@ android {
     }
 
 
+    val keystorePath = System.getenv("KEYSTORE_FILE")
+        ?: keystoreProps.getProperty("storeFile", "")
+
     signingConfigs {
         create("release") {
-            storeFile = file(
-                System.getenv("KEYSTORE_FILE")
-                    ?: keystoreProps.getProperty("storeFile", "")
-            )
+            if (keystorePath.isNotEmpty()) {
+                storeFile = file(keystorePath)
+            }
             storePassword = System.getenv("KEYSTORE_PASSWORD")
                 ?: keystoreProps.getProperty("storePassword", "")
             keyAlias = System.getenv("KEY_ALIAS")


### PR DESCRIPTION
## Description
The web release CI build (`wasmJsBrowserDistribution`) was failing because Gradle evaluates all project build files during configuration — including `androidApp/build.gradle.kts`. When the `KEYSTORE_FILE` env var is absent (as in the web-only build job), the signing config resolved to `file("")`, which Gradle rejects with `Cannot convert '' to File`.

## Changes Made
- `androidApp/build.gradle.kts` — extract the keystore path into a local variable and only assign `storeFile` when the path is non-empty

## Type of Change
- [x] Bug fix

## Testing Done
- [x] Verified the Android build path is unchanged (env var present → `storeFile` is set)
- [x] Verified the web build path no longer hits the empty-file error (env var absent → `storeFile` assignment is skipped)

## Checklist
- [x] Code follows project style guidelines
- [x] No breaking changes

Made with [Cursor](https://cursor.com)