### PR TITLE
[FIX] Proxy crypto icon CDN on wasmJs and support CJK symbols

### DIFF
--- a/composeApp/src/androidMain/kotlin/ktx/CryptoIcon.android.kt
+++ b/composeApp/src/androidMain/kotlin/ktx/CryptoIcon.android.kt
@@ -1,0 +1,3 @@
+package ktx
+
+internal actual val useBrowserSafeIconCdn: Boolean = false

--- a/composeApp/src/commonMain/kotlin/ktx/CryptoIcon.kt
+++ b/composeApp/src/commonMain/kotlin/ktx/CryptoIcon.kt
@@ -1,5 +1,65 @@
 package ktx
 
-/** Base asset → Binance static CDN icon URL. */
-fun cryptoIconUrl(baseAsset: String): String =
-    "https://bin.bnbstatic.com/static/assets/logos/${baseAsset.uppercase()}.png"
+/**
+ * Per-platform flag: should we route coin icon requests through a browser-safe
+ * proxy?
+ *
+ * On wasmJs the Binance static CDN (`bin.bnbstatic.com`) returns HTTP 503 to
+ * browser-origin requests — its WAF keys on headers like `Origin` and
+ * `Sec-Fetch-Site: cross-site` that native Ktor HTTP engines do not send.
+ * The web build therefore proxies via `images.weserv.nl`, a long-running
+ * CORS-friendly image proxy that re-serves the same bytes with
+ * `Access-Control-Allow-Origin: *`.
+ *
+ * Native targets (Android/iOS/desktop) use a native HTTP stack that sails
+ * through Binance's WAF unchanged, so they hit the CDN directly for the
+ * lowest latency and the broadest Binance-native icon coverage.
+ */
+internal expect val useBrowserSafeIconCdn: Boolean
+
+/**
+ * Build the icon URL for a given base asset (e.g. `"BTC"`, `"币安人生"`).
+ *
+ * Pure-ASCII symbols are uppercased to match Binance's file-naming convention
+ * (`BTC.png`, `ETH.png`). CJK / mixed symbols are kept verbatim since Binance
+ * stores them that way (`币安人生.png`). The resulting filename is percent-
+ * encoded so non-ASCII characters survive URL transport intact.
+ *
+ * Returns an empty string only for empty input — callers can treat that as a
+ * signal to render a text fallback instead of making any request.
+ */
+fun cryptoIconUrl(baseAsset: String): String {
+    if (baseAsset.isEmpty()) return ""
+    val filename = if (isAsciiAlphaNum(baseAsset)) baseAsset.uppercase() else baseAsset
+    val encoded = percentEncode(filename)
+    val binancePath = "bin.bnbstatic.com/static/assets/logos/$encoded.png"
+    return if (useBrowserSafeIconCdn) {
+        "https://images.weserv.nl/?url=$binancePath"
+    } else {
+        "https://$binancePath"
+    }
+}
+
+private fun isAsciiAlphaNum(s: String): Boolean =
+    s.all { it in 'A'..'Z' || it in 'a'..'z' || it in '0'..'9' }
+
+/** RFC 3986 percent-encoding for a path segment: unreserved chars pass through, everything else becomes %XX. */
+private fun percentEncode(s: String): String = buildString {
+    for (byte in s.encodeToByteArray()) {
+        val b = byte.toInt() and 0xFF
+        val isUnreserved =
+            (b in 'A'.code..'Z'.code) ||
+            (b in 'a'.code..'z'.code) ||
+            (b in '0'.code..'9'.code) ||
+            b == '-'.code || b == '_'.code || b == '.'.code || b == '~'.code
+        if (isUnreserved) {
+            append(b.toChar())
+        } else {
+            append('%')
+            append(HEX[b ushr 4])
+            append(HEX[b and 0x0F])
+        }
+    }
+}
+
+private val HEX = "0123456789ABCDEF".toCharArray()

--- a/composeApp/src/commonMain/kotlin/ui/CryptoListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/CryptoListScreen.kt
@@ -1232,7 +1232,7 @@ private fun CoinIcon(
             .background(MaterialTheme.colorScheme.surfaceVariant),
         contentAlignment = Alignment.Center
     ) {
-        if (errored || baseAsset.isEmpty()) {
+        if (errored || iconUrl.isEmpty()) {
             Text(
                 text = baseAsset.take(1),
                 style = MaterialTheme.typography.labelSmall,

--- a/composeApp/src/desktopMain/kotlin/ktx/CryptoIcon.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/ktx/CryptoIcon.desktop.kt
@@ -1,0 +1,3 @@
+package ktx
+
+internal actual val useBrowserSafeIconCdn: Boolean = false

--- a/composeApp/src/iosMain/kotlin/ktx/CryptoIcon.ios.kt
+++ b/composeApp/src/iosMain/kotlin/ktx/CryptoIcon.ios.kt
@@ -1,0 +1,3 @@
+package ktx
+
+internal actual val useBrowserSafeIconCdn: Boolean = false

--- a/composeApp/src/wasmJsMain/kotlin/ktx/CryptoIcon.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/ktx/CryptoIcon.wasmJs.kt
@@ -1,0 +1,3 @@
+package ktx
+
+internal actual val useBrowserSafeIconCdn: Boolean = true

--- a/composeApp/src/wasmJsMain/kotlin/theme/Typography.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/theme/Typography.wasmJs.kt
@@ -24,28 +24,47 @@ fun NotoSansFontFamily(): FontFamily? {
 
     LaunchedEffect(Unit) {
         try {
-            // Load all fonts in parallel using coroutines
-            val (light, normal, medium, semiBold, bold) = coroutineScope {
+            // Load all fonts in parallel using coroutines.
+            // NotoSansSC-VF is a variable font covering Simplified Chinese (and
+            // most common CJK ideographs) — it's the fallback that lets Skiko
+            // render tickers like "币安人生" instead of .notdef boxes.
+            val bytes = coroutineScope {
                 listOf(
                     async { readResourceBytes("NotoSans-Light.ttf") },
                     async { readResourceBytes("NotoSans-Regular.ttf") },
                     async { readResourceBytes("NotoSans-Medium.ttf") },
                     async { readResourceBytes("NotoSans-SemiBold.ttf") },
-                    async { readResourceBytes("NotoSans-Bold.ttf") }
+                    async { readResourceBytes("NotoSans-Bold.ttf") },
+                    async { readResourceBytes("NotoSansSC-VF.ttf") }
                 ).awaitAll()
             }
+            val light = bytes[0]
+            val normal = bytes[1]
+            val medium = bytes[2]
+            val semiBold = bytes[3]
+            val bold = bytes[4]
+            val cjk = bytes[5]
 
             // Create FontFamily only when all fonts are loaded
             if (light.isNotEmpty() && normal.isNotEmpty() &&
                 medium.isNotEmpty() && semiBold.isNotEmpty() &&
-                bold.isNotEmpty()) {
+                bold.isNotEmpty() && cjk.isNotEmpty()) {
 
                 fontFamily = FontFamily(
+                    // Primary Latin fonts — matched first by weight.
                     Font("NotoSans_Light", light, weight = FontWeight.Light),
                     Font("NotoSans_Normal", normal, weight = FontWeight.Normal),
                     Font("NotoSans_Medium", medium, weight = FontWeight.Medium),
                     Font("NotoSans_SemiBold", semiBold, weight = FontWeight.SemiBold),
-                    Font("NotoSans_Bold", bold, weight = FontWeight.Bold)
+                    Font("NotoSans_Bold", bold, weight = FontWeight.Bold),
+                    // CJK fallback — same variable-font bytes registered per weight.
+                    // Skiko picks the Latin font for ASCII glyphs and falls back
+                    // to NotoSansSC per-glyph for missing (e.g. CJK) characters.
+                    Font("NotoSansSC_Light", cjk, weight = FontWeight.Light),
+                    Font("NotoSansSC_Normal", cjk, weight = FontWeight.Normal),
+                    Font("NotoSansSC_Medium", cjk, weight = FontWeight.Medium),
+                    Font("NotoSansSC_SemiBold", cjk, weight = FontWeight.SemiBold),
+                    Font("NotoSansSC_Bold", cjk, weight = FontWeight.Bold)
                 )
             }
         } catch (e: Exception) {


### PR DESCRIPTION
## Description
Fixes broken crypto coin icons on the web (wasmJs) build and adds CJK character rendering support. Binance's static CDN returns HTTP 503 for browser-origin requests due to WAF headers — this change routes wasmJs icon requests through a CORS-friendly proxy while keeping native targets on the direct CDN path.

## Changes Made
- **`CryptoIcon.kt` (commonMain)** — Refactored `cryptoIconUrl()` to use an `expect val useBrowserSafeIconCdn` flag. Added percent-encoding for non-ASCII base-asset names (CJK tickers like `币安人生`).
- **`CryptoIcon.android.kt` / `CryptoIcon.desktop.kt` / `CryptoIcon.ios.kt`** — `actual val useBrowserSafeIconCdn = false` (direct CDN).
- **`CryptoIcon.wasmJs.kt`** — `actual val useBrowserSafeIconCdn = true` (proxy via `images.weserv.nl`).
- **`CryptoListScreen.kt`** — Fixed `CoinIcon` fallback to check `iconUrl.isEmpty()` instead of `baseAsset.isEmpty()`.
- **`Typography.wasmJs.kt`** — Added NotoSansSC variable font loading with per-weight CJK fallback entries for Skiko rendering.
- **`NotoSansSC-VF.ttf`** — New Noto Sans SC variable font resource for wasmJs.

## Type of Change
- [x] Bug fix
- [x] New feature

## Testing Done
- [ ] Manual testing on Web (wasmJs) — coin icons load via proxy
- [ ] Manual testing on Android — coin icons load directly from CDN
- [ ] Manual testing on Desktop — coin icons load directly from CDN
- [ ] CJK ticker symbols render correctly on Web

## Checklist
- [x] Code follows project style guidelines
- [x] No breaking changes
- [x] Platform expect/actual pattern used correctly

## Related Issues
N/A

Made with [Cursor](https://cursor.com)