### PR TITLE
[REFACTOR] Conditionally show trading pair label in TickerCard

### DIFF
--- a/composeApp/src/commonMain/kotlin/ui/CryptoListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/CryptoListScreen.kt
@@ -831,6 +831,7 @@ fun TickerCard(
     selectedTradingPair: String,
     tradingPairs: List<model.TradingPair>,
     cryptoViewModel: CryptoViewModel,
+    showTradingPair: Boolean = false,
     onClick: (String, String) -> Unit = { _, _ -> }
 ) {
     // Use composition local for settings to avoid recomposition
@@ -928,13 +929,15 @@ fun TickerCard(
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )
-                        Text(
-                            text = actualTradingPair,
-                            fontSize = 12.sp,
-                            color = Color.Gray,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
+                        if (showTradingPair) {
+                            Text(
+                                text = actualTradingPair,
+                                fontSize = 12.sp,
+                                color = Color.Gray,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
                         Spacer(Modifier.height(4.dp))
                         AnimatedContent(
                             targetState = formattedVolume,
@@ -1204,6 +1207,7 @@ fun FavoritesListScreen(
                                         priceChangePercent = tickerData.priceChangePercent,
                                         tradingPairs = tradingPairs,
                                         cryptoViewModel = cryptoViewModel,
+                                        showTradingPair = true,
                                         onClick = onCoinClick
                                     )
                                 }


### PR DESCRIPTION
## Description
Hide the trading pair label in the main market list's TickerCard for a cleaner, less cluttered layout. The trading pair remains visible in the Favorites screen where the extra context is useful.

## Changes Made
- Added `showTradingPair: Boolean = false` parameter to `TickerCard` composable in `CryptoListScreen.kt`
- Wrapped the trading pair `Text` in an `if (showTradingPair)` guard so it is hidden by default
- Passed `showTradingPair = true` in `FavoritesListScreen` to preserve the existing favorites behavior

## Type of Change
- [x] Refactoring

## Testing Done
- [ ] Manual testing on Android
- [ ] Manual testing on iOS (if applicable)
- [ ] Manual testing on Desktop (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] No breaking changes (or documented if present)

## Related Issues
N/A

Made with [Cursor](https://cursor.com)