### PR TITLE
chore(release): bump version to 0.4.2

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "org.androdevlinux.utxo"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 40
-        versionName = "0.4.0"
+        versionCode = 42
+        versionName = "0.4.2"
     }
 
     val keystorePropsFile = rootProject.file("keystore.properties")

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -25,7 +25,7 @@
     <string name="settings_use_dark_theme">Use dark theme</string>
     <string name="settings_about">About</string>
     <string name="settings_version">Version</string>
-    <string name="settings_version_number">0.4.0</string>
+    <string name="settings_version_number">0.4.2</string>
     <string name="settings_privacy_policy">Privacy Policy</string>
     <string name="settings_website">Website</string>
     <string name="settings_github">Github</string>


### PR DESCRIPTION
## Summary
- Bumps Android `versionCode` 40 → 42 and `versionName` 0.4.0 → 0.4.2 in `androidApp/build.gradle.kts`
- Updates in-app "About" string `settings_version_number` 0.4.0 → 0.4.2 so UI matches the build
- Release AAB built locally (not committed)

## Test plan
- [ ] CI build succeeds (Android, iOS, Desktop, Web)
- [ ] Install the release build and verify Settings → About shows **0.4.2**
- [ ] `ktlintCheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)