### PR TITLE
[FIX] Release workflow respects repo rules; bumps from version.properties

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
           - web
         default: both
       version_override:
-        description: "Version tag override (leave blank to auto-increment patch, e.g. v0.3.7 -> v0.3.8)"
+        description: "Version tag override (leave blank to auto-increment patch from version.properties, e.g. 0.4.2 -> v0.4.3)"
         required: false
         type: string
         default: ""
@@ -46,61 +46,58 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       new_tag: ${{ steps.version.outputs.new_tag }}
+      new_name: ${{ steps.version.outputs.new_name }}
+      new_code: ${{ steps.version.outputs.new_code }}
       prev_tag: ${{ steps.version.outputs.prev_tag }}
-      new_code: ${{ steps.bump.outputs.new_code }}
       changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - name: Checkout (full history)
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Resolve version
         id: version
         run: |
           PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 
+          BASE_NAME=$(grep '^versionName=' version.properties | cut -d= -f2)
+          BASE_CODE=$(grep '^versionCode=' version.properties | cut -d= -f2)
+
           if [ -n "${{ inputs.version_override }}" ]; then
             NEW_TAG="${{ inputs.version_override }}"
-          elif [ -z "$PREV_TAG" ]; then
+            NEW_NAME="${NEW_TAG#v}"
+          elif [ -z "$BASE_NAME" ]; then
             NEW_TAG="v0.0.1"
+            NEW_NAME="0.0.1"
           else
-            VERSION="${PREV_TAG#v}"
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_NAME"
             PATCH=$((PATCH + 1))
-            NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+            NEW_NAME="${MAJOR}.${MINOR}.${PATCH}"
+            NEW_TAG="v${NEW_NAME}"
           fi
 
+          NEW_CODE=$((BASE_CODE + 1))
+
           if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
-            echo "::error::Tag $NEW_TAG already exists. Use a different version_override or delete the existing tag."
+            echo "::error::Tag $NEW_TAG already exists. Bump version.properties via PR or pass version_override."
             exit 1
           fi
 
-          echo "prev_tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
-          echo "new_tag=${NEW_TAG}" >> "$GITHUB_OUTPUT"
-          echo "Resolved version: ${PREV_TAG:-<none>} -> ${NEW_TAG}"
+          {
+            echo "prev_tag=${PREV_TAG}"
+            echo "new_tag=${NEW_TAG}"
+            echo "new_name=${NEW_NAME}"
+            echo "new_code=${NEW_CODE}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved: base=${BASE_NAME}/${BASE_CODE} -> ${NEW_TAG} (code ${NEW_CODE})"
 
-      - name: Bump app version files
-        id: bump
-        run: |
-          NEW_TAG="${{ steps.version.outputs.new_tag }}"
-          NEW_NAME="${NEW_TAG#v}"
-          CUR_CODE=$(grep '^versionCode=' version.properties | cut -d= -f2)
-          NEW_CODE=$((CUR_CODE + 1))
-          bash scripts/bump-version.sh "$NEW_NAME" "$NEW_CODE"
-          echo "new_code=$NEW_CODE" >> "$GITHUB_OUTPUT"
-          echo "Bumped to ${NEW_NAME} (${NEW_CODE})"
-
-      - name: Commit bump and create tag
+      - name: Create and push tag
         run: |
           NEW_TAG="${{ steps.version.outputs.new_tag }}"
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add version.properties iosApp/iosApp.xcodeproj/project.pbxproj
-          git commit -m "chore(release): bump version to ${NEW_TAG}"
-          git push origin HEAD:${{ github.ref_name }}
-          git tag "$NEW_TAG"
+          git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
           git push origin "$NEW_TAG"
 
       - name: Generate changelog
@@ -239,6 +236,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.new_tag }}
+          fetch-depth: 1
 
       - name: Decode keystore
         run: |
@@ -250,7 +248,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        run: ./gradlew :androidApp:assembleRelease
+        run: ./gradlew :androidApp:assembleRelease -PappVersionName=${{ needs.prepare.outputs.new_name }} -PappVersionCode=${{ needs.prepare.outputs.new_code }}
 
       - name: Build release AAB
         if: inputs.build_aab
@@ -259,7 +257,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        run: ./gradlew :androidApp:bundleRelease
+        run: ./gradlew :androidApp:bundleRelease -PappVersionName=${{ needs.prepare.outputs.new_name }} -PappVersionCode=${{ needs.prepare.outputs.new_code }}
 
       - name: Rename APK
         run: |
@@ -308,6 +306,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.new_tag }}
+          fetch-depth: 1
 
       - name: Build wasmJs distribution
         run: ./gradlew :composeApp:wasmJsBrowserDistribution

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -12,6 +12,14 @@ val versionProps = Properties().apply {
     rootProject.file("version.properties").inputStream().use { load(it) }
 }
 
+val resolvedVersionName: String =
+    (project.findProperty("appVersionName") as? String)?.takeIf { it.isNotBlank() }
+        ?: versionProps.getProperty("versionName")
+
+val resolvedVersionCode: Int =
+    (project.findProperty("appVersionCode") as? String)?.toIntOrNull()
+        ?: versionProps.getProperty("versionCode").toInt()
+
 android {
     namespace = "org.androdevlinux.utxo.app"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
@@ -20,8 +28,8 @@ android {
         applicationId = "org.androdevlinux.utxo"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = versionProps.getProperty("versionCode").toInt()
-        versionName = versionProps.getProperty("versionName")
+        versionCode = resolvedVersionCode
+        versionName = resolvedVersionName
     }
 
     val keystorePropsFile = rootProject.file("keystore.properties")


### PR DESCRIPTION
## Description

Fixes two production bugs hit on the first run of the new release workflow (#234):

1. **`refs/heads/main` push rejected** — the repo's ruleset requires PRs and signed commits. The bot's `git push origin HEAD:main` step was rejected with `GH013: Cannot update this protected ref` + missing signature. The release workflow can't commit the version bump back to `main`.

2. **Wrong tag computed** — auto-increment was reading from `git describe --tags --abbrev=0`, which returned `v0.3.11` (the last actually-released tag). It proposed `v0.3.12` instead of the expected `v0.4.3` (current `version.properties` says `0.4.2`).

## Approach

Stop trying to mutate files in CI. Pass the resolved version to Gradle via `-P` properties at build time so the artifact carries the right version without touching `version.properties` or `pbxproj` in the workflow.

## Changes

- **`androidApp/build.gradle.kts`** — adds `resolvedVersionName` / `resolvedVersionCode` that prefer `-PappVersionName` / `-PappVersionCode` and fall back to `version.properties`. Local builds still work from the file; CI overrides per-release.
- **`.github/workflows/release.yml`** —
  - `Resolve version` now reads the baseline from `version.properties` (not `git describe --tags`). `0.4.2` → bump patch → `v0.4.3`. `versionCode` = current + 1 = `43`.
  - Drops the `Bump app version files` and `Commit bump and create tag` steps entirely. No more `git push origin HEAD:main`.
  - New `Create and push tag` step does just `git tag -a $NEW_TAG -m "Release $NEW_TAG"` + `git push origin $NEW_TAG`. The branch ruleset only targets `branch`, so `refs/tags/*` is unaffected and the default `GITHUB_TOKEN` can push tags without bypass.
  - Build jobs pass `-PappVersionName=${{ needs.prepare.outputs.new_name }} -PappVersionCode=${{ needs.prepare.outputs.new_code }}` to `assembleRelease` and `bundleRelease`.
  - Build jobs keep `ref: ${{ needs.prepare.outputs.new_tag }}` so the artifacts are reproducible from that exact tag.
- **`scripts/bump-version.sh` and `version.properties` are unchanged** — the script remains as a local helper for the user to update files (and iOS `pbxproj`) via a normal PR when they want to advance the baseline.

## Maintenance flow after this lands

- **Releases:** trigger workflow → it computes next tag from `version.properties` (file `0.4.2` → tag `v0.4.3`) and publishes that. No changes to `main` from CI.
- **Advancing the baseline (e.g. when you want the next release to be `v0.5.0`):** locally run `bash scripts/bump-version.sh 0.5.0 50`, commit (signed), open a PR, merge. Then the next workflow run will release `v0.5.1` (file `0.5.0` → bump → `0.5.1`). To release exactly `v0.5.0`, use `version_override: v0.5.0` on the dispatch.
- **iOS:** the script still patches `pbxproj` so when you archive in Xcode after a baseline bump, the iOS build matches. Same as before — not part of CI.

## Type of Change
- [x] Bug fix
- [x] Refactoring (release tooling)

## Testing Done
- [x] `./gradlew :androidApp:help -PappVersionName=0.4.3 -PappVersionCode=43` parses cleanly (exit 0).
- [x] Verified `version.properties` parsing: `BASE_NAME=0.4.2`, `BASE_CODE=42` → `NEW_NAME=0.4.3`, `NEW_CODE=43`, `NEW_TAG=v0.4.3`.
- [x] Confirmed `refs/tags/*` is not covered by the active rulesets (only `branch` target).
- [ ] End-to-end: trigger Release workflow after merge — expected outcome: tag `v0.4.3` created on main HEAD, APK reports `0.4.3 (43)`, GitHub release titled `UTXO v0.4.3`.

## Notes for Reviewer

- The first commit on `main` after this lands won't be signed by me (no GPG key locally) — the GitHub squash-merge will sign it via web-flow, satisfying the ruleset.
- This intentionally keeps `version.properties` slightly behind reality after each release (file says 0.4.2 even though v0.4.3 is out). That's a known trade-off of not pushing back to main; it serves as the "next baseline to bump from." Acceptable given repo rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)