### PR TITLE
[FIX] Sync settings_version_number string with release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,6 +238,9 @@ jobs:
           ref: ${{ needs.prepare.outputs.new_tag }}
           fetch-depth: 1
 
+      - name: Sync version files in workspace
+        run: bash scripts/bump-version.sh "${{ needs.prepare.outputs.new_name }}" "${{ needs.prepare.outputs.new_code }}"
+
       - name: Decode keystore
         run: |
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > "${RUNNER_TEMP}/release.jks"
@@ -248,7 +251,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        run: ./gradlew :androidApp:assembleRelease -PappVersionName=${{ needs.prepare.outputs.new_name }} -PappVersionCode=${{ needs.prepare.outputs.new_code }}
+        run: ./gradlew :androidApp:assembleRelease
 
       - name: Build release AAB
         if: inputs.build_aab
@@ -257,7 +260,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        run: ./gradlew :androidApp:bundleRelease -PappVersionName=${{ needs.prepare.outputs.new_name }} -PappVersionCode=${{ needs.prepare.outputs.new_code }}
+        run: ./gradlew :androidApp:bundleRelease
 
       - name: Rename APK
         run: |
@@ -307,6 +310,9 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.new_tag }}
           fetch-depth: 1
+
+      - name: Sync version files in workspace
+        run: bash scripts/bump-version.sh "${{ needs.prepare.outputs.new_name }}" "${{ needs.prepare.outputs.new_code }}"
 
       - name: Build wasmJs distribution
         run: ./gradlew :composeApp:wasmJsBrowserDistribution

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -12,14 +12,6 @@ val versionProps = Properties().apply {
     rootProject.file("version.properties").inputStream().use { load(it) }
 }
 
-val resolvedVersionName: String =
-    (project.findProperty("appVersionName") as? String)?.takeIf { it.isNotBlank() }
-        ?: versionProps.getProperty("versionName")
-
-val resolvedVersionCode: Int =
-    (project.findProperty("appVersionCode") as? String)?.toIntOrNull()
-        ?: versionProps.getProperty("versionCode").toInt()
-
 android {
     namespace = "org.androdevlinux.utxo.app"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
@@ -28,8 +20,8 @@ android {
         applicationId = "org.androdevlinux.utxo"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = resolvedVersionCode
-        versionName = resolvedVersionName
+        versionCode = versionProps.getProperty("versionCode").toInt()
+        versionName = versionProps.getProperty("versionName")
     }
 
     val keystorePropsFile = rootProject.file("keystore.properties")

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -13,6 +13,7 @@ NEW_CODE="$2"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PROPS="$ROOT/version.properties"
 PBXPROJ="$ROOT/iosApp/iosApp.xcodeproj/project.pbxproj"
+STRINGS="$ROOT/composeApp/src/commonMain/composeResources/values/strings.xml"
 
 cat > "$PROPS" <<EOF
 versionName=$NEW_NAME
@@ -22,5 +23,8 @@ EOF
 sed -i.bak -E "s/(MARKETING_VERSION = )[0-9]+(\.[0-9]+)+;/\1${NEW_NAME};/g" "$PBXPROJ"
 sed -i.bak -E "s/(CURRENT_PROJECT_VERSION = )[0-9]+;/\1${NEW_CODE};/g" "$PBXPROJ"
 rm -f "${PBXPROJ}.bak"
+
+sed -i.bak -E "s|(<string name=\"settings_version_number\">)[^<]+(</string>)|\1${NEW_NAME}\2|g" "$STRINGS"
+rm -f "${STRINGS}.bak"
 
 echo "bumped to versionName=$NEW_NAME versionCode=$NEW_CODE"


### PR DESCRIPTION
## Description

The settings screen renders the version from a **hardcoded string resource** ([composeApp/src/commonMain/composeResources/values/strings.xml:28](composeApp/src/commonMain/composeResources/values/strings.xml:28)), not from `BuildConfig.VERSION_NAME`. v0.4.3 shipped successfully — the APK has the right `versionName` in its manifest — but the in-app **About → Version** text still reads "0.4.2" because the resource string was never updated.

## Approach

Two paths considered:
- **Proper fix**: switch the UI to `expect val appVersion: String` with platform actuals (`BuildConfig.VERSION_NAME` on Android, `Bundle.main.infoDictionary` on iOS, etc.). Right architecturally but requires 4 platform actuals + Context plumbing for Android.
- **Mechanical fix (taken)**: have `scripts/bump-version.sh` also patch the resource string, and run the script in CI before each build. One line in the script, one workflow step per build job. Local builds and Xcode archives also stay in sync because the script is the same one users already run for iOS.

## Changes

- **`scripts/bump-version.sh`** — adds a `sed` patch for `<string name="settings_version_number">…</string>` alongside the existing `version.properties` and pbxproj updates.
- **`.github/workflows/release.yml`** — each build job (`build-android`, `build-web`) gains a "Sync version files in workspace" step that runs the script after checkout, before any Gradle invocation. Workspace-only mutation; no commit/push.
- **`androidApp/build.gradle.kts`** — reverts the `-PappVersionName`/`-PappVersionCode` fallback added in #235. Now that the script writes `version.properties` in the build workspace, the simple file read is the single mechanism. Drops the `-P` flags from the workflow's Gradle commands too.

## Testing Done

- [x] Ran `bash scripts/bump-version.sh 0.4.4 44` locally; verified all three files updated:
  - `version.properties` → `0.4.4` / `44`
  - `pbxproj` → `MARKETING_VERSION = 0.4.4`, `CURRENT_PROJECT_VERSION = 44`
  - `strings.xml` → `<string name="settings_version_number">0.4.4</string>`
- [x] Reverted with `bash scripts/bump-version.sh 0.4.2 42`; clean diff.
- [ ] End-to-end: requires the next release dispatch.

## How to verify after merge

The `version.properties` file on `main` is currently `0.4.2/42`. The next workflow dispatch would auto-bump to `v0.4.3` — but **`v0.4.3` already exists** as a tag (the broken release), so the workflow will error out.

To get a corrected release, pick one:
1. **Cleanest:** dispatch with `version_override: v0.4.4` — cuts a fresh `v0.4.4` with the strings.xml fix applied. The broken `v0.4.3` stays as a release artifact but you ship `v0.4.4` immediately.
2. **Re-release v0.4.3:** delete the `v0.4.3` tag and release on GitHub, then dispatch — the workflow will rebuild `v0.4.3` with the fix.

I'd recommend (1) — non-destructive, and `v0.4.4` is just one number up.

After verification, you'll see "Version 0.4.4" in the Settings screen on the new build, matching the GitHub release name and the APK manifest.

## Notes

- Long-term: consider switching to `BuildConfig.VERSION_NAME` via `expect/actual` so the UI version is always derived from the build, not a separately-maintained string. That's its own PR.
- Same script change benefits iOS: when you archive in Xcode after running `bash scripts/bump-version.sh X.Y.Z N` locally, the iOS build's settings screen will also show the right version (since strings.xml is in `commonMain`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)