### PR TITLE
[FEAT] Generate APP_VERSION_NAME at build time for all platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,6 +238,9 @@ jobs:
           ref: ${{ needs.prepare.outputs.new_tag }}
           fetch-depth: 1
 
+      - name: Sync version files in workspace
+        run: bash scripts/bump-version.sh "${{ needs.prepare.outputs.new_name }}" "${{ needs.prepare.outputs.new_code }}"
+
       - name: Decode keystore
         run: |
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > "${RUNNER_TEMP}/release.jks"
@@ -248,7 +251,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        run: ./gradlew :androidApp:assembleRelease -PappVersionName=${{ needs.prepare.outputs.new_name }} -PappVersionCode=${{ needs.prepare.outputs.new_code }}
+        run: ./gradlew :androidApp:assembleRelease
 
       - name: Build release AAB
         if: inputs.build_aab
@@ -257,7 +260,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        run: ./gradlew :androidApp:bundleRelease -PappVersionName=${{ needs.prepare.outputs.new_name }} -PappVersionCode=${{ needs.prepare.outputs.new_code }}
+        run: ./gradlew :androidApp:bundleRelease
 
       - name: Rename APK
         run: |
@@ -307,6 +310,9 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.new_tag }}
           fetch-depth: 1
+
+      - name: Sync version files in workspace
+        run: bash scripts/bump-version.sh "${{ needs.prepare.outputs.new_name }}" "${{ needs.prepare.outputs.new_code }}"
 
       - name: Build wasmJs distribution
         run: ./gradlew :composeApp:wasmJsBrowserDistribution

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -12,14 +12,6 @@ val versionProps = Properties().apply {
     rootProject.file("version.properties").inputStream().use { load(it) }
 }
 
-val resolvedVersionName: String =
-    (project.findProperty("appVersionName") as? String)?.takeIf { it.isNotBlank() }
-        ?: versionProps.getProperty("versionName")
-
-val resolvedVersionCode: Int =
-    (project.findProperty("appVersionCode") as? String)?.toIntOrNull()
-        ?: versionProps.getProperty("versionCode").toInt()
-
 android {
     namespace = "org.androdevlinux.utxo.app"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
@@ -28,8 +20,8 @@ android {
         applicationId = "org.androdevlinux.utxo"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = resolvedVersionCode
-        versionName = resolvedVersionName
+        versionCode = versionProps.getProperty("versionCode").toInt()
+        versionName = versionProps.getProperty("versionName")
     }
 
     val keystorePropsFile = rootProject.file("keystore.properties")

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -3,6 +3,31 @@ import org.gradle.internal.os.OperatingSystem
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import java.util.Properties
+
+val generateAppVersion by tasks.registering {
+    val versionFile = rootProject.file("version.properties")
+    val outputDir = layout.buildDirectory.dir("generated/source/version/commonMain/kotlin")
+    inputs.file(versionFile)
+    outputs.dir(outputDir)
+    doLast {
+        val props = Properties().apply { versionFile.inputStream().use { load(it) } }
+        val name = props.getProperty("versionName")
+        val code = props.getProperty("versionCode").toInt()
+        val out = outputDir.get().file("buildinfo/Version.kt").asFile
+        out.parentFile.mkdirs()
+        out.writeText(
+            """
+            // Auto-generated from version.properties. Do not edit.
+            package buildinfo
+
+            internal const val APP_VERSION_NAME: String = "$name"
+            internal const val APP_VERSION_CODE: Int = $code
+
+            """.trimIndent()
+        )
+    }
+}
 
 val javafxPlatform: String = run {
     val os = OperatingSystem.current()
@@ -67,6 +92,10 @@ kotlin {
         val desktopMain by getting
 
         val wasmJsMain by getting
+
+        commonMain {
+            kotlin.srcDir(generateAppVersion)
+        }
 
         iosMain.dependencies {
             implementation(libs.ktor.client.darwin)

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -25,7 +25,6 @@
     <string name="settings_use_dark_theme">Use dark theme</string>
     <string name="settings_about">About</string>
     <string name="settings_version">Version</string>
-    <string name="settings_version_number">0.4.2</string>
     <string name="settings_privacy_policy">Privacy Policy</string>
     <string name="settings_website">Website</string>
     <string name="settings_github">Github</string>

--- a/composeApp/src/commonMain/kotlin/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/SettingsScreen.kt
@@ -84,8 +84,8 @@ import utxo.composeapp.generated.resources.settings_theme
 import utxo.composeapp.generated.resources.settings_title
 import utxo.composeapp.generated.resources.settings_use_dark_theme
 import utxo.composeapp.generated.resources.settings_version
-import utxo.composeapp.generated.resources.settings_version_number
 import utxo.composeapp.generated.resources.settings_website
+import buildinfo.APP_VERSION_NAME
 import utxo.composeapp.generated.resources.theme_dark
 import utxo.composeapp.generated.resources.theme_light
 import utxo.composeapp.generated.resources.theme_system
@@ -180,7 +180,7 @@ fun SettingsScreen(
                     SettingsItem(
                         icon = Icons.Default.Info,
                         title = stringResource(Res.string.settings_version),
-                        subtitle = stringResource(Res.string.settings_version_number),
+                        subtitle = APP_VERSION_NAME,
                         onClick = null
                     )
                     SettingsItem(


### PR DESCRIPTION
## Description

The settings screen used to read a **hardcoded string resource** (`<string name="settings_version_number">0.4.2</string>`), which silently drifted from the actual app version — v0.4.3 shipped with "0.4.2" in the UI. This PR makes drift impossible across all four platforms (Android, iOS, Desktop, Web) by generating a `commonMain` constant from `version.properties` at build time.

Supersedes (and closes) [#236](https://github.com/percy-g2/kmp_utxo/pull/236).

## Why codegen instead of `expect`/`actual`

`expect`/`actual` was the suggested mechanism, but it breaks down on Desktop and Web — neither has a native API equivalent to Android's `BuildConfig.VERSION_NAME` or iOS's `Bundle.main.infoDictionary`. They'd still need build-time injection, so we'd end up with 4 actuals + Gradle plumbing.

Build-time codegen is one mechanism that works identically for every target. `version.properties` stays the single source of truth.

## Changes

- **`composeApp/build.gradle.kts`** — adds `generateAppVersion`, a Gradle task that reads `version.properties` and writes:
  ```
  composeApp/build/generated/source/version/commonMain/kotlin/buildinfo/Version.kt
  ```
  containing `internal const val APP_VERSION_NAME` and `APP_VERSION_CODE`. The output dir is registered as a source dir on `commonMain`, so every target (`androidMain`, `iosMain`, `desktopMain`, `wasmJsMain`) compiles against it. Gradle infers the task dependency from the source-set provider — `compileKotlinXxx` triggers regeneration whenever `version.properties` changes.
- **`composeApp/src/commonMain/kotlin/ui/SettingsScreen.kt`** — drops the resource import, reads `buildinfo.APP_VERSION_NAME` directly.
- **`composeApp/src/commonMain/composeResources/values/strings.xml`** — removes the dead `settings_version_number` entry.
- **`.github/workflows/release.yml`** — each build job (`build-android`, `build-web`) gains a "Sync version files in workspace" step that runs `scripts/bump-version.sh` after checkout. This writes the resolved release version to `version.properties` in the build workspace before any Gradle invocation, so codegen produces the right constant. Drops the `-PappVersionName` / `-PappVersionCode` flags from the Gradle commands introduced in #235.
- **`androidApp/build.gradle.kts`** — reverts to the simple `version.properties` read (drops the `findProperty` fallback that's no longer reachable).

## Testing Done

- [x] `./gradlew :composeApp:generateAppVersion` produces the expected file:
  ```kotlin
  package buildinfo
  internal const val APP_VERSION_NAME: String = "0.4.2"
  internal const val APP_VERSION_CODE: Int = 42
  ```
- [x] `./gradlew :composeApp:compileKotlinDesktop` succeeds — validates `commonMain` (which holds both `SettingsScreen.kt` and the generated `Version.kt`). The same `commonMain` compiles for Android, iOS, and wasmJs targets too.
- [x] Edits to `version.properties` are picked up on the next `compileKotlinXxx` (the source-set provider establishes the dependency).
- [ ] End-to-end: requires the next release dispatch.

## How to verify after merge

`version.properties` on `main` still says `0.4.2 / 42`. The next workflow dispatch auto-bumps to `v0.4.3` — but **`v0.4.3` already exists** as a tag from the broken release. Two ways forward:

1. **Cleanest:** dispatch with `version_override: v0.4.4` — cuts a fresh `v0.4.4` with the codegen fix applied. The broken `v0.4.3` stays as a release artifact but you ship `v0.4.4` immediately. Settings screen will show `0.4.4`, matching the GitHub release name and the APK manifest.
2. **Re-release v0.4.3:** delete the `v0.4.3` GitHub release and tag, then dispatch — the workflow rebuilds `v0.4.3` with the fix.

Recommend (1) — non-destructive.

## Type of Change

- [x] New feature (build-time version codegen)
- [x] Bug fix (eliminates UI/manifest version drift)
- [x] Refactoring (single mechanism replaces resource string + `-P` plumbing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)