### PR TITLE
[FIX] Self-progressing release version bump (no more version_override)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,27 +60,30 @@ jobs:
         id: version
         run: |
           PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-
+          PREV_VER="${PREV_TAG#v}"
           BASE_NAME=$(grep '^versionName=' version.properties | cut -d= -f2)
-          BASE_CODE=$(grep '^versionCode=' version.properties | cut -d= -f2)
 
           if [ -n "${{ inputs.version_override }}" ]; then
             NEW_TAG="${{ inputs.version_override }}"
             NEW_NAME="${NEW_TAG#v}"
-          elif [ -z "$BASE_NAME" ]; then
-            NEW_TAG="v0.0.1"
-            NEW_NAME="0.0.1"
           else
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_NAME"
+            # Floor = highest of (version.properties, latest git tag).
+            # Lets the file act as a manual jump (e.g. set to 1.0.0 for major bump)
+            # while normally auto-progressing from the last released tag.
+            HIGHEST=$(printf '%s\n%s\n' "${PREV_VER:-0.0.0}" "${BASE_NAME:-0.0.0}" | sort -V | tail -n1)
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$HIGHEST"
             PATCH=$((PATCH + 1))
             NEW_NAME="${MAJOR}.${MINOR}.${PATCH}"
             NEW_TAG="v${NEW_NAME}"
           fi
 
-          NEW_CODE=$((BASE_CODE + 1))
+          # versionCode is derived from versionName: MAJOR*10000 + MINOR*100 + PATCH.
+          # Deterministic and monotonic as long as MINOR/PATCH stay <100 (more than enough headroom).
+          IFS='.' read -r N_MAJOR N_MINOR N_PATCH <<< "$NEW_NAME"
+          NEW_CODE=$((N_MAJOR * 10000 + N_MINOR * 100 + N_PATCH))
 
           if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
-            echo "::error::Tag $NEW_TAG already exists. Bump version.properties via PR or pass version_override."
+            echo "::error::Tag $NEW_TAG already exists. Pass version_override with a higher version."
             exit 1
           fi
 
@@ -90,7 +93,7 @@ jobs:
             echo "new_name=${NEW_NAME}"
             echo "new_code=${NEW_CODE}"
           } >> "$GITHUB_OUTPUT"
-          echo "Resolved: base=${BASE_NAME}/${BASE_CODE} -> ${NEW_TAG} (code ${NEW_CODE})"
+          echo "Resolved: file=${BASE_NAME:-<none>} tag=${PREV_TAG:-<none>} -> ${NEW_TAG} (code ${NEW_CODE})"
 
       - name: Create and push tag
         run: |


### PR DESCRIPTION
## Description

Auto-increment in `release.yml` was reading only `version.properties`, which goes stale after every release because we don't push the bump back to `main`. So `file=0.4.2` + existing tag `v0.4.3` produced "Tag v0.4.3 already exists" on every dispatch — the user had to pass `version_override` every single release.

This makes the workflow self-progressing: the next version is always `max(file, latest_tag) + 1 patch`, with `versionCode` derived deterministically from the version name. After this lands, `version.properties` is just a manual-jump knob (set to `1.0.0` to force a major bump) and you don't touch it for normal patch releases.

## Changes

- **Resolve version step** —
  - `HIGHEST = max(version.properties versionName, latest git tag stripped of v)` using `sort -V` for proper semver ordering.
  - Bump patch → `NEW_NAME`.
  - `NEW_CODE = MAJOR*10000 + MINOR*100 + PATCH`. Stateless, monotonic. Headroom is fine — `MINOR`/`PATCH` stay <100 in practice.
  - Drops the `versionCode` read from `version.properties` (no longer needed in CI; the file's value still feeds local debug builds).

## Why deterministic `versionCode`

The previous `BASE_CODE + 1` bug: file=42, broken `v0.4.3` shipped with code 43, rebuilt `v0.4.3` would also compute 43 → Play Store would reject as duplicate. The new formula gives `v0.4.4 → 404`, comfortably above the broken 43, monotonic for every future release.

## Verification

Tested all 6 scenarios locally with the actual bash logic:

| Scenario | prev tag | file | expected | result |
|---|---|---|---|---|
| Current state (file behind tag) | v0.4.3 | 0.4.2 | v0.4.4 / 404 | ✓ |
| Manual jump via file | v0.4.3 | 1.0.0 | v1.0.1 / 10001 | ✓ |
| Tag behind file (legacy) | v0.3.11 | 0.4.2 | v0.4.3 / 403 | ✓ |
| First release | (none) | 0.0.0 | v0.0.1 / 1 | ✓ |
| Same on both | v0.5.0 | 0.5.0 | v0.5.1 / 501 | ✓ |
| Patch >9 (sort -V) | v0.4.10 | 0.4.2 | v0.4.11 / 411 | ✓ |

## After this lands

Trigger the Release workflow with no override. Expected:
- `git describe` returns `v0.4.3` (broken release tag).
- File `0.4.2` ≤ tag `0.4.3`, so floor = `0.4.3`.
- Bump → `v0.4.4`, code `404`.
- APK reports `0.4.4 (404)`. Settings UI shows `0.4.4` (codegen from #237).
- GitHub release named `UTXO v0.4.4`.

Future releases all auto-increment from the latest tag — no manual file edits or overrides needed.

## Type of Change

- [x] Bug fix (eliminates recurring "tag already exists" friction)
- [x] Refactoring (single source of truth: latest released tag, with file as override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)