### PR TITLE
fix(android): embed native debug symbols in release AAB

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -77,6 +77,9 @@ android {
             isShrinkResources = true
             signingConfig = signingConfigs.getByName("release")
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "../composeApp/proguard-rules.pro")
+            ndk {
+                debugSymbolLevel = "FULL"
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `ndk { debugSymbolLevel = "FULL" }` to the `release` build type in `androidApp/build.gradle.kts`
- `bundleRelease` now packages native debug symbols (currently for the transitive `libandroidx.graphics.path.so` across all 4 ABIs) under `BUNDLE-METADATA/com.android.tools.build.debugsymbols/` inside the AAB
- Clears the Play Console warning: *"This App Bundle contains native code, and you've not uploaded debug symbols"* and yields symbolicated native crash/ANR stack traces

## Why

Symbols embedded in the AAB are auto-extracted by Play Console on upload — no workflow changes, no separate Play Developer API integration, no service-account secret required. Symbols live in `BUNDLE-METADATA/` which Play strips before delivering split APKs to devices, so user install size is unaffected.

`FULL` (vs `SYMBOL_TABLE`) gives full DWARF debug info including line numbers and inlined frames; size delta is negligible for one small transitive `.so`.

## Test plan

- [ ] CI green
- [ ] Run `./gradlew :androidApp:bundleRelease` (or dispatch the release workflow with `build_aab=true`)
- [ ] Verify symbols embedded: `unzip -l androidApp/build/outputs/bundle/release/*.aab | grep debugsymbols` — expect one entry per ABI
- [ ] Upload AAB to Play Console (internal track) and confirm the native-debug-symbols warning no longer appears

## Follow-up (not in this PR)

Play also surfaces a separate prompt for the ProGuard/R8 `mapping.txt` (Java/Kotlin deobfuscation). That file is already being generated at `androidApp/build/outputs/mapping/release/mapping.txt` — a future change could attach it as a GitHub Actions artifact alongside the AAB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)