### PR TITLE
[FIX] Unblock wasmJS news and trading pairs in browser

### DIFF
--- a/composeApp/src/androidMain/kotlin/App.android.kt
+++ b/composeApp/src/androidMain/kotlin/App.android.kt
@@ -74,9 +74,9 @@ actual fun createNewsHttpClient(): HttpClient {
     }
 }
 
-actual fun wrapRssUrlForPlatform(url: String): String {
+actual fun wrapRssUrlForPlatform(url: String): List<String> {
     // No CORS restrictions on Android, return URL as-is
-    return url
+    return listOf(url)
 }
 
 actual fun getPendingCoinDetailFromIntent(): Pair<String, String>? {

--- a/composeApp/src/androidMain/kotlin/ExchangeInfoFlag.android.kt
+++ b/composeApp/src/androidMain/kotlin/ExchangeInfoFlag.android.kt
@@ -1,0 +1,1 @@
+internal actual val useExchangeInfoForMarginSymbols: Boolean = false

--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -368,7 +368,9 @@ expect fun openLink(link: String)
 
 expect fun createNewsHttpClient(): HttpClient
 
-expect fun wrapRssUrlForPlatform(url: String): String
+expect fun wrapRssUrlForPlatform(url: String): List<String>
+
+internal expect val useExchangeInfoForMarginSymbols: Boolean
 
 expect fun getPendingCoinDetailFromIntent(): Pair<String, String>?
 

--- a/composeApp/src/commonMain/kotlin/model/Symbol.kt
+++ b/composeApp/src/commonMain/kotlin/model/Symbol.kt
@@ -30,3 +30,36 @@ data class TradingPair(
     val status: String,
     val delistedTime: String? = null
 )
+
+@Serializable
+internal data class ExchangeInfoResponse(val symbols: List<ExchangeSymbol>)
+
+@Serializable
+internal data class ExchangeSymbol(
+    val symbol: String,
+    val status: String,
+    val baseAsset: String,
+    val quoteAsset: String,
+    val isSpotTradingAllowed: Boolean = false,
+    val isMarginTradingAllowed: Boolean = false,
+    val permissions: List<String> = emptyList()
+)
+
+internal fun ExchangeInfoResponse.toMarginSymbols(): MarginSymbols = MarginSymbols(
+    code = "000000",
+    message = null,
+    messageDetail = null,
+    data = symbols.map { s ->
+        TradingPair(
+            id = s.symbol,
+            symbol = s.symbol,
+            base = s.baseAsset,
+            quote = s.quoteAsset,
+            isMarginTrade = s.isMarginTradingAllowed || "MARGIN" in s.permissions,
+            isBuyAllowed = s.status == "TRADING",
+            isSellAllowed = s.status == "TRADING",
+            status = s.status,
+            delistedTime = null
+        )
+    }
+)

--- a/composeApp/src/commonMain/kotlin/network/HttpClient.kt
+++ b/composeApp/src/commonMain/kotlin/network/HttpClient.kt
@@ -1,5 +1,6 @@
 package network
 
+import useExchangeInfoForMarginSymbols
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
@@ -7,7 +8,6 @@ import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.logging.SIMPLE
 import io.ktor.client.request.get
-import io.ktor.client.request.headers
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
@@ -21,9 +21,11 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
 import logging.AppLogger
+import model.ExchangeInfoResponse
 import model.MarginSymbols
 import model.UiKline
 import model.UiKlineSerializer
+import model.toMarginSymbols
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -118,15 +120,21 @@ class HttpClient {
 
     suspend fun fetchMarginSymbols(): MarginSymbols? {
         return try {
-            val response: HttpResponse = client.get("https://www.binance.com/bapi/margin/v1/public/margin/symbols") {
-                headers {
-                    append("Accept-Encoding", "identity")
-                    append("User-Agent", "Mozilla/5.0")
+            if (useExchangeInfoForMarginSymbols) {
+                // Browser path: Binance's bapi host is blocked by its WAF for browser-origin
+                // requests, so use the documented CORS-enabled public API instead.
+                val response: HttpResponse = client.get("https://api.binance.com/api/v3/exchangeInfo") {
+                    parameter("permissions", "MARGIN")
                 }
+                if (response.status == HttpStatusCode.OK) {
+                    json.decodeFromString<ExchangeInfoResponse>(response.bodyAsText()).toMarginSymbols()
+                } else null
+            } else {
+                val response: HttpResponse = client.get("https://www.binance.com/bapi/margin/v1/public/margin/symbols")
+                if (response.status == HttpStatusCode.OK) {
+                    json.decodeFromString<MarginSymbols>(response.bodyAsText())
+                } else null
             }
-            if (response.status == HttpStatusCode.OK) {
-                json.decodeFromString<MarginSymbols>(response.bodyAsText())
-            } else null
         } catch (e: Exception) {
             AppLogger.logger.e(throwable = e) { "Error fetching margin symbols" }
             null

--- a/composeApp/src/commonMain/kotlin/network/NewsService.kt
+++ b/composeApp/src/commonMain/kotlin/network/NewsService.kt
@@ -2,9 +2,11 @@ package network
 
 import createNewsHttpClient
 import io.ktor.client.call.body
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.request.get
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -46,27 +48,31 @@ class NewsService {
     }
 
     private suspend fun fetchRSSFeed(url: String, coinSymbol: String): List<NewsItem>? {
-        return try {
-            // Wrap URL with CORS proxy for WASM/web platform, or return as-is for other platforms
-            val wrappedUrl = wrapRssUrlForPlatform(url)
-            val response: HttpResponse = httpClient.get(wrappedUrl)
-            if (response.status == HttpStatusCode.OK) {
-                val xmlContent = withContext(Dispatchers.Default) {
-                    response.body<String>()
+        // wasmJS returns a fallback chain of CORS proxies; native platforms return [url].
+        val candidates = wrapRssUrlForPlatform(url)
+        for ((idx, candidate) in candidates.withIndex()) {
+            try {
+                val response: HttpResponse = httpClient.get(candidate)
+                if (response.status == HttpStatusCode.OK) {
+                    val xmlContent = withContext(Dispatchers.Default) {
+                        response.body<String>()
+                    }
+                    if (url.contains("coindesk", ignoreCase = true)) {
+                        AppLogger.logger.d { "CoinDesk RSS sample (first 500 chars): ${xmlContent.take(500)}" }
+                    }
+                    return parseRSSFeed(xmlContent, coinSymbol)
                 }
-                // Debug: log first 500 chars to see feed structure
-                if (url.contains("coindesk", ignoreCase = true)) {
-                    AppLogger.logger.d { "CoinDesk RSS sample (first 500 chars): ${xmlContent.take(500)}" }
-                }
-                parseRSSFeed(xmlContent, coinSymbol)
-            } else {
-                AppLogger.logger.w { "RSS feed returned status ${response.status} for $url" }
-                null
+                AppLogger.logger.w { "RSS candidate ${idx + 1}/${candidates.size} returned ${response.status} for $url" }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: HttpRequestTimeoutException) {
+                AppLogger.logger.w(throwable = e) { "RSS candidate ${idx + 1}/${candidates.size} timed out for $url" }
+            } catch (e: Exception) {
+                AppLogger.logger.w(throwable = e) { "RSS candidate ${idx + 1}/${candidates.size} failed for $url" }
             }
-        } catch (e: Exception) {
-            AppLogger.logger.e(throwable = e) { "Error fetching RSS feed $url" }
-            null
         }
+        AppLogger.logger.w { "All ${candidates.size} RSS candidates failed for $url" }
+        return null
     }
 
     private fun parseRSSFeed(xml: String, coinSymbol: String): List<NewsItem> {

--- a/composeApp/src/desktopMain/kotlin/App.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/App.desktop.kt
@@ -93,9 +93,9 @@ actual fun createNewsHttpClient(): HttpClient {
     }
 }
 
-actual fun wrapRssUrlForPlatform(url: String): String {
+actual fun wrapRssUrlForPlatform(url: String): List<String> {
     // No CORS restrictions on Desktop, return URL as-is
-    return url
+    return listOf(url)
 }
 
 actual fun openLink(link: String) {

--- a/composeApp/src/desktopMain/kotlin/ExchangeInfoFlag.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/ExchangeInfoFlag.desktop.kt
@@ -1,0 +1,1 @@
+internal actual val useExchangeInfoForMarginSymbols: Boolean = false

--- a/composeApp/src/iosMain/kotlin/App.ios.kt
+++ b/composeApp/src/iosMain/kotlin/App.ios.kt
@@ -122,9 +122,9 @@ actual fun createNewsHttpClient(): HttpClient {
     }
 }
 
-actual fun wrapRssUrlForPlatform(url: String): String {
+actual fun wrapRssUrlForPlatform(url: String): List<String> {
     // No CORS restrictions on iOS, return URL as-is
-    return url
+    return listOf(url)
 }
 
 actual fun getPendingCoinDetailFromIntent(): Pair<String, String>? {

--- a/composeApp/src/iosMain/kotlin/ExchangeInfoFlag.ios.kt
+++ b/composeApp/src/iosMain/kotlin/ExchangeInfoFlag.ios.kt
@@ -1,0 +1,1 @@
+internal actual val useExchangeInfoForMarginSymbols: Boolean = false

--- a/composeApp/src/wasmJsMain/kotlin/App.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/App.wasmJs.kt
@@ -3,6 +3,7 @@ import io.github.xxfast.kstore.KStore
 import io.github.xxfast.kstore.storage.storeOf
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.js.Js
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
@@ -65,6 +66,11 @@ actual fun createNewsHttpClient(): HttpClient {
         install(ContentNegotiation) {
             json()
         }
+        install(HttpTimeout) {
+            connectTimeoutMillis = 10_000
+            requestTimeoutMillis = 20_000
+            socketTimeoutMillis = 20_000
+        }
     }
 }
 
@@ -76,11 +82,14 @@ actual fun syncSettingsToWidget(settings: ui.Settings) {
     // No-op for WASM/web - no widgets
 }
 
-actual fun wrapRssUrlForPlatform(url: String): String {
-    // Use CORS proxy for WASM/web platform to bypass CORS restrictions
-    // Using allorigins.win as a reliable CORS proxy service
-    val encodedUrl = encodeURIComponent(url)
-    return "https://api.allorigins.win/raw?url=$encodedUrl"
+actual fun wrapRssUrlForPlatform(url: String): List<String> {
+    // Browser fetch is subject to CORS, so route RSS feeds through a fallback chain
+    // of public CORS proxies. corsproxy.io first (more reliable), allorigins.win as backup.
+    val encoded = encodeURIComponent(url)
+    return listOf(
+        "https://corsproxy.io/?url=$encoded",
+        "https://api.allorigins.win/raw?url=$encoded"
+    )
 }
 
 @JsName("encodeURIComponent")

--- a/composeApp/src/wasmJsMain/kotlin/ExchangeInfoFlag.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/ExchangeInfoFlag.wasmJs.kt
@@ -1,0 +1,1 @@
+internal actual val useExchangeInfoForMarginSymbols: Boolean = true


### PR DESCRIPTION
## Description

Two wasmJS-only network failures fixed:

1. **News (RSS) failed on every wasmJS client** — laptop and mobile both. The single CORS proxy (`api.allorigins.win`) was unreliable, and the wasmJS news client had no timeout, so a hung proxy froze the UI indefinitely.
2. **`fetchMarginSymbols()` failed on mobile wasmJS** while working on desktop wasmJS. Binance's WAF blocks browser-origin requests to `www.binance.com/bapi/...` (same root cause already documented in [`ktx/CryptoIcon.kt`](composeApp/src/commonMain/kotlin/ktx/CryptoIcon.kt) for the icon CDN). Mobile networks trip the WAF more aggressively than desktop. The forbidden `User-Agent` / `Accept-Encoding` headers also triggered CORS preflight rejection on stricter mobile clients.

Native targets (Android, iOS, desktop JVM) were never affected and remain on the existing code paths.

## Changes Made

**News (`NewsService` + `App.wasmJs.kt`)**
- `wrapRssUrlForPlatform(url)` now returns `List<String>` of candidates instead of a single `String`.
- wasmJS returns `[corsproxy.io, allorigins.win]` as a fallback chain; native actuals return `[url]`.
- `NewsService.fetchRSSFeed` iterates the candidates, catches `HttpRequestTimeoutException` and other failures cleanly to try the next, rethrows `CancellationException`.
- Installed `HttpTimeout` (10s connect / 20s request / 20s socket) on the wasmJS news client.

**Trading pairs (`HttpClient` + new `ExchangeInfoFlag.<platform>.kt`)**
- New expect/actual `useExchangeInfoForMarginSymbols: Boolean` (`true` only on wasmJS), mirroring the existing `useBrowserSafeIconCdn` pattern.
- On wasmJS, `fetchMarginSymbols` now calls the public CORS-enabled `api.binance.com/api/v3/exchangeInfo?permissions=MARGIN`.
- Added `ExchangeInfoResponse` model + `toMarginSymbols()` mapper in `model/Symbol.kt` to preserve the existing `MarginSymbols` return shape — zero downstream churn.
- Removed forbidden `User-Agent` and `Accept-Encoding` headers unconditionally (browsers silently drop them; native engines set their own UA).

**Files touched**
- `composeApp/src/commonMain/kotlin/App.kt` — expect signatures
- `composeApp/src/commonMain/kotlin/network/NewsService.kt` — candidate iteration
- `composeApp/src/commonMain/kotlin/network/HttpClient.kt` — branch on flag, drop headers
- `composeApp/src/commonMain/kotlin/model/Symbol.kt` — `ExchangeInfoResponse` + mapper
- `composeApp/src/wasmJsMain/kotlin/App.wasmJs.kt` — `HttpTimeout`, proxy chain
- `composeApp/src/{android,ios,desktop}Main/kotlin/App.<plat>.kt` — `wrapRssUrlForPlatform` returns single-element list
- `composeApp/src/{wasmJs,android,ios,desktop}Main/kotlin/ExchangeInfoFlag.<plat>.kt` — new (one bool each)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance improvement

## Testing Done
- [x] All four targets compile cleanly (`compileKotlinWasmJs`, `compileAndroidMain`, `compileDevKotlinDesktop`, `compileKotlinIosSimulatorArm64`)
- [ ] Manual testing on wasmJS in mobile browser (cellular) — pending merge
- [ ] Manual testing on wasmJS in desktop browser — pending merge
- [x] Native paths untouched: `useExchangeInfoForMarginSymbols = false` and `wrapRssUrlForPlatform` returns `listOf(url)` on Android/iOS/Desktop

**Verification in browser DevTools after merge:**
1. Network tab → `api.binance.com/api/v3/exchangeInfo?permissions=MARGIN` returns 200 with `Access-Control-Allow-Origin: *`. No `OPTIONS` preflight failure.
2. RSS XHRs go to `corsproxy.io` first; block that domain via DevTools "Block request URL" → fallback to `allorigins.win` fires within ~20s.
3. Console: no `Refused to set unsafe header` warnings for `User-Agent` / `Accept-Encoding`.

## Checklist
- [x] Code follows project style guidelines (reuses existing expect/actual patterns)
- [x] All targets compile locally
- [x] No breaking changes — public API of `MarginSymbols` / `TradingPair` unchanged

## Notes / Risks
- `exchangeInfo` payload is ~1.5 MB — acceptable for a one-shot init call.
- `isBuyAllowed` / `isSellAllowed` are approximated as `status == "TRADING"` in the mapper; `grep` confirmed downstream code only reads `pair.quote`, so the approximation is safe.
- Both CORS proxies are free public services. The fallback chain handles single-vendor failure but not "all proxies down." Long-term mitigation (out of scope here): host a tiny Cloudflare Worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)