### PR TITLE
docs: clarify phone/tablet screenshots are cross-platform

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ Examples: `feat/i18n-strings`, `fix/websocket-reconnection`, `refactor/settings-
 | `pcr` | "pcr", "push commit review", "full pipeline" |
 | `deploy-ss` | "make store screenshots", "feature graphic", "App Store assets", "Play Store assets" |
 
-`deploy-ss` is the only non-git skill in the table. It turns raw app UI captures (in `raw-screenshots/`, gitignored) into the polished `screenshots/` set used in the README and store listings: 5 iPhone + 5 iPad + 1 Play Store feature graphic, all at submission-ready dimensions. The skill bundles its own Python renderer, Inter fonts, and design references — see `.claude/skills/deploy-ss/SKILL.md`.
+`deploy-ss` is the only non-git skill in the table. It turns raw app UI captures (in `raw-screenshots/`, gitignored — currently sourced from the Android build) into the polished `screenshots/` set used in the README and store listings: 5 phone shots at 1284 × 2778 (App Store + Play Store), 5 tablet shots at 2048 × 2732 (App Store iPad slot only — Play Store tablet listings would need a separate render pass at Google's 7" / 10" dimensions), and 1 Play Store feature graphic at 1024 × 500. Phone shots use an iPhone-styled bezel but ship to both stores; Compose Multiplatform means the underlying UI is identical across Android and iOS. The skill bundles its own Python renderer, Inter fonts, and design references — see `.claude/skills/deploy-ss/SKILL.md`.
 
 ## Build Commands
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ A modern, cross-platform cryptocurrency tracking application built with Kotlin M
   <img src="screenshots/feature_graphic_1024x500.png" width="100%" alt="UTXO — Crypto markets in your pocket">
 </p>
 
-<p align="center"><sub><b>iPhone</b> · 1284 × 2778 · App Store + Play Store</sub></p>
+<p align="center"><sub><b>Phone</b> · Android · iOS · 1284 × 2778 · App Store + Play Store</sub></p>
+<p align="center"><sub><i>UI captured from the Android build; the same Compose Multiplatform code runs on iOS.</i></sub></p>
 
 <table>
   <tr>
@@ -28,7 +29,8 @@ A modern, cross-platform cryptocurrency tracking application built with Kotlin M
   </tr>
 </table>
 
-<p align="center"><sub><b>iPad</b> · 2048 × 2732 · App Store iPad slot</sub></p>
+<p align="center"><sub><b>Tablet</b> · Android · iOS · 2048 × 2732 · App Store iPad slot</sub></p>
+<p align="center"><sub><i>Sized for Apple's iPad slot. Play Store tablet listings would need a separate render pass at Google's recommended 7" / 10" dimensions.</i></sub></p>
 
 <table>
   <tr>

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -431,7 +431,7 @@
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 45;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = 37UYJHD27F;
 				ENABLE_PREVIEWS = YES;
@@ -447,7 +447,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.2;
+				MARKETING_VERSION = 0.4.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = org.androdevlinux.utxo.UTXO;
 				PRODUCT_NAME = "${APP_NAME}";
@@ -465,7 +465,7 @@
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 42;
+				CURRENT_PROJECT_VERSION = 45;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = 37UYJHD27F;
 				ENABLE_PREVIEWS = YES;
@@ -481,7 +481,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.2;
+				MARKETING_VERSION = 0.4.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = org.androdevlinux.utxo.UTXO;
 				PRODUCT_NAME = "${APP_NAME}";


### PR DESCRIPTION
## Description

Two-part update on the docs branch:

1. **Docs (AGENTS.md, README.md)** — relabels the README screenshot sections from iPhone/iPad → Phone/Tablet (Android · iOS), since Compose Multiplatform produces identical UI on both platforms and the same renders ship to App Store and Play Store. Adds notes that current `screenshots/` are captured from the Android build, and documents store-specific dimension caveats (tablet shots are sized for Apple's iPad slot only; Play Store tablet listings would need a separate render pass at Google's 7" / 10" dimensions). AGENTS.md `deploy-ss` row gets the same context.

2. **chore(ios)** — bumps `iosApp.xcodeproj/project.pbxproj` for the next TestFlight / App Store submission:
   - `MARKETING_VERSION` 0.4.2 → 0.4.5 (Debug + Release)
   - `CURRENT_PROJECT_VERSION` 42 → 45 (Debug + Release)

## Changes Made

- `AGENTS.md` — expand `deploy-ss` row with sourcing, dimensions, and store-coverage details
- `README.md` — relabel screenshot section headers and add cross-platform / dimension caveat sub-notes
- `iosApp/iosApp.xcodeproj/project.pbxproj` — version + build number bump (Debug + Release configs)

## Type of Change

- [x] Documentation update
- [x] Other: iOS marketing/build version bump (chore)

## Testing Done

- [x] Visual check that README still renders cleanly on GitHub
- [x] AGENTS.md `deploy-ss` row reads cleanly
- [ ] iOS build archives with the new version (recommend: open `iosApp/` in Xcode and confirm the version banner)

## Checklist

- [x] Conventional commit format (`docs:` and `chore(ios):`)
- [x] No code logic changes; no tests affected
- [x] No secrets or sensitive files

## Related Issues

None.