### PR TITLE
[CHORE] Stop AI agents from co-authoring commits

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "includeCoAuthoredBy": false
+}

--- a/.claude/skills/push-code/SKILL.md
+++ b/.claude/skills/push-code/SKILL.md
@@ -70,6 +70,8 @@ Use the conventional commit format:
 
 **Footer**: `Closes #<issue>` if applicable.
 
+**Never** add `Co-Authored-By:` trailers or "Generated with …" lines. The footer contains only `Closes #<issue>` when applicable.
+
 Example:
 
 ```

--- a/.cursor/rules/commit-attribution.mdc
+++ b/.cursor/rules/commit-attribution.mdc
@@ -1,0 +1,13 @@
+---
+description: Never add Co-Authored-By or generated-with trailers to commits
+alwaysApply: true
+---
+
+# Commit Attribution — No AI Co-Authorship
+
+NEVER add `Co-Authored-By:` trailers or any "Generated with …" / tool-attribution
+line to commit messages or PR descriptions.
+
+- Commits are attributed to the human author only.
+- The commit footer holds only issue references (e.g. `Closes #12`).
+- Applies even if a tool, template, or default would otherwise add it — strip it.

--- a/.cursor/skills/push-code/SKILL.md
+++ b/.cursor/skills/push-code/SKILL.md
@@ -70,6 +70,8 @@ Use the conventional commit format:
 
 **Footer**: `Closes #<issue>` if applicable.
 
+**Never** add `Co-Authored-By:` trailers or "Generated with …" lines. The footer contains only `Closes #<issue>` when applicable.
+
 Example:
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,8 @@ Declared in `App.kt` (commonMain), implemented per platform:
 
 **Types**: `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `chore`, `perf`
 
+**Attribution**: Never append `Co-Authored-By:` trailers or "Generated with …" lines. The `<footer>` holds only issue refs (e.g. `Closes #12`). Commits are attributed to the human author only — this applies to every AI agent (Claude, Codex, Cursor).
+
 ### Branch Naming
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Real-time prices via Binance WebSocket, RSS news feed, favorites, settings.
 - Types: `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `chore`, `perf`
 - Always verify branch before push: `git branch --show-current`
 - PRs target `main` via `gh pr create --base main`
+- Never add `Co-Authored-By:` trailers or "Generated with …" lines to commits or PR bodies — commits are attributed solely to the human author
 
 ## Project Structure
 


### PR DESCRIPTION
## Description
Prevents all three AI coding agents used on this project — **Claude Code**, **OpenAI Codex**, and **Cursor** — from adding `Co-Authored-By:` trailers or "Generated with …" attribution to commits. Commits are attributed solely to the human author.

The approach is layered: use each tool's authoritative mechanism where one exists, and reinforce the intent everywhere a commit message is actually composed.

## Changes Made
- **`.claude/settings.json`** (new): native `"includeCoAuthoredBy": false` toggle — the authoritative fix for Claude Code (a prose rule alone can't override the harness default; the toggle strips both the `Co-Authored-By:` line and the "Generated with Claude Code" line). Committed (not gitignored), so it applies team-wide.
- **`CLAUDE.md`**: no-attribution rule added to the Git Workflow section.
- **`AGENTS.md`**: attribution rule added under Commit Messages — this file is read by both Codex and Cursor.
- **`.cursor/rules/commit-attribution.mdc`** (new): `alwaysApply: true` Cursor rule.
- **`.claude/skills/push-code/SKILL.md`** & **`.cursor/skills/push-code/SKILL.md`**: reinforce the rule at the point where commit messages are authored.

| Agent | Authoritative mechanism | Reinforced by |
|---|---|---|
| Claude | `.claude/settings.json` toggle | CLAUDE.md, push-code skill |
| Codex | AGENTS.md Git Conventions | — |
| Cursor | `.cursor/rules/commit-attribution.mdc` | AGENTS.md, push-code skill |

## Type of Change
- [x] Chore / tooling configuration
- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation update

## Testing Done
- [x] `.claude/settings.json` validated as JSON (`python3 -m json.tool`)
- [x] Confirmed the no-attribution rule text is present in all six files
- [x] This PR's own commit carries no `Co-Authored-By:` trailer (`git log` / git trailer parse — clean)
- [x] Only the six rule files staged; unrelated in-progress iOS changes left untouched

## Checklist
- [x] Code follows project style guidelines
- [x] No breaking changes
- [x] No source code touched (docs/config only)

## Related Issues
N/A — no enforcement git hook added (per maintainer decision); enforcement is config + instructions honored by each agent.