### PR TITLE
[FEATURE] Add real-time Hyperliquid portfolio (read-only)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -115,4 +115,50 @@
     <!-- Scroll buttons -->
     <string name="scroll_to_top">Scroll to top</string>
     <string name="scroll_to_bottom">Scroll to bottom</string>
+
+    <!-- Portfolio Settings -->
+    <string name="settings_portfolio">Portfolio</string>
+    <string name="settings_hyperliquid_address">Hyperliquid wallet address</string>
+    <string name="settings_hyperliquid_address_hint">0x… (public address, read-only)</string>
+    <string name="settings_hyperliquid_invalid">Must be 0x followed by 40 hex characters</string>
+    <string name="settings_save">Save</string>
+    <string name="settings_clear">Clear</string>
+
+    <!-- Portfolio Screen -->
+    <string name="portfolio_title">Portfolio</string>
+    <string name="portfolio_account_value">Account Value</string>
+    <string name="portfolio_unrealized_pnl">Unrealized PnL</string>
+    <string name="portfolio_margin_used">Margin Used</string>
+    <string name="portfolio_withdrawable">Withdrawable</string>
+    <string name="portfolio_perp_positions">Perpetual Positions</string>
+    <string name="portfolio_spot_balances">Spot Balances</string>
+    <string name="portfolio_long">Long</string>
+    <string name="portfolio_short">Short</string>
+    <string name="portfolio_entry">Entry</string>
+    <string name="portfolio_mark">Mark</string>
+    <string name="portfolio_liq">Liq.</string>
+    <string name="portfolio_margin">Margin</string>
+    <string name="portfolio_roe">ROE</string>
+    <string name="portfolio_available">Avail.</string>
+    <string name="portfolio_hold">On hold</string>
+    <string name="portfolio_empty">Nothing here yet</string>
+    <string name="portfolio_empty_hint">This wallet has no open positions or balances.</string>
+    <string name="portfolio_no_address">No wallet configured</string>
+    <string name="portfolio_no_address_hint">Add your Hyperliquid wallet address in Settings to view your portfolio.</string>
+    <string name="portfolio_invalid_address">Invalid wallet address</string>
+    <string name="portfolio_invalid_address_hint">The configured address must be 0x followed by 40 hex characters.</string>
+    <string name="portfolio_load_error">Couldn\'t load portfolio</string>
+    <string name="portfolio_load_error_hint">Check your connection and try again.</string>
+    <string name="portfolio_retry">Retry</string>
+    <string name="portfolio_open_settings">Open Settings</string>
+    <string name="portfolio_reconnecting">Reconnecting…</string>
+    <string name="portfolio_value">Portfolio Value</string>
+    <string name="portfolio_live">Live</string>
+    <string name="portfolio_account">Account</string>
+    <string name="portfolio_free">Free</string>
+    <string name="portfolio_positions">Positions</string>
+    <string name="portfolio_spot">Spot</string>
+    <string name="portfolio_size">Size</string>
+    <string name="portfolio_away">away</string>
+    <string name="portfolio_allocation">Allocation</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -22,9 +22,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.TransformOrigin
@@ -50,6 +48,7 @@ import model.CoinDetail
 import model.Favorites
 import model.Market
 import model.NavItem
+import model.Portfolio
 import model.Settings
 import org.jetbrains.compose.resources.stringResource
 import theme.ThemeManager.store
@@ -59,7 +58,9 @@ import ui.CoinDetailScreen
 import ui.CryptoList
 import ui.CryptoViewModel
 import ui.FavoritesListScreen
+import ui.PortfolioScreen
 import ui.SettingsScreen
+import ui.isValidHyperliquidAddress
 import ui.utils.isDarkTheme
 import utxo.composeapp.generated.resources.Res
 import utxo.composeapp.generated.resources.network_unavailable
@@ -83,7 +84,7 @@ fun App(
         settingsState?.let { syncSettingsToWidget(it) }
     }
     val navBackStackEntry by navController.currentBackStackEntryAsState()
-    var selectedItem by rememberSaveable { mutableIntStateOf(0) }
+    val currentDestinationId = navBackStackEntry?.destination?.id
     val networkObserver = remember { NetworkConnectivityObserver() }
     val networkStatus by networkObserver.observe().collectAsState(initial = null)
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -190,26 +191,28 @@ fun App(
         }
     }
 
-    // Simplified navigation state management
-    LaunchedEffect(navBackStackEntry?.destination?.id) {
-        val destinationId = navBackStackEntry?.destination?.id ?: return@LaunchedEffect
-        
-        when (destinationId) {
-            Market.serializer().generateHashCode() -> {
-                selectedItem = 0
-                cryptoViewModel.resume()
-            }
-            Favorites.serializer().generateHashCode() -> {
-                selectedItem = 1
-                cryptoViewModel.resume()
-            }
-            Settings.serializer().generateHashCode() -> {
-                selectedItem = 2
-                cryptoViewModel.pause()
-            }
-            CoinDetail.serializer().generateHashCode() -> {
-                selectedItem = 3
-                cryptoViewModel.pause()
+    // Pause the market stream on screens that don't need it; resume on the list screens.
+    LaunchedEffect(currentDestinationId) {
+        when (currentDestinationId) {
+            Market.serializer().generateHashCode(),
+            Favorites.serializer().generateHashCode() -> cryptoViewModel.resume()
+            Portfolio.serializer().generateHashCode(),
+            Settings.serializer().generateHashCode(),
+            CoinDetail.serializer().generateHashCode() -> cryptoViewModel.pause()
+            else -> {}
+        }
+    }
+
+    // If the wallet address is cleared/invalidated while the user is on the Portfolio
+    // tab, the tab disappears — redirect to Market so they aren't stranded.
+    LaunchedEffect(currentDestinationId, settingsState?.hyperliquidWalletAddress) {
+        val onPortfolio = currentDestinationId == Portfolio.serializer().generateHashCode()
+        val enabled = isValidHyperliquidAddress(settingsState?.hyperliquidWalletAddress.orEmpty())
+        if (onPortfolio && !enabled) {
+            navController.navigate(Market) {
+                popUpTo(navController.graph.startDestinationId) { saveState = true }
+                launchSingleTop = true
+                restoreState = true
             }
         }
     }
@@ -222,17 +225,22 @@ fun App(
         Scaffold(
             modifier = Modifier.fillMaxSize(),
             bottomBar = {
-                if (selectedItem != 3) {
+                val isCoinDetail = currentDestinationId == CoinDetail.serializer().generateHashCode()
+                if (!isCoinDetail) {
                     BottomAppBar(
                         actions = {
-                            val navItems = listOf(
-                                NavItem.HomeScreen,
-                                NavItem.FavoritesScreen,
-                                NavItem.SettingsScreen
+                            val portfolioEnabled = isValidHyperliquidAddress(
+                                settingsState?.hyperliquidWalletAddress.orEmpty()
                             )
+                            val navItems = buildList {
+                                add(NavItem.HomeScreen)
+                                add(NavItem.FavoritesScreen)
+                                if (portfolioEnabled) add(NavItem.PortfolioScreen)
+                                add(NavItem.SettingsScreen)
+                            }
 
                             NavigationBar {
-                                navItems.forEachIndexed { index, item ->
+                                navItems.forEach { item ->
                                     NavigationBarItem(
                                         alwaysShowLabel = false,
                                         icon = {
@@ -242,9 +250,8 @@ fun App(
                                             )
                                         },
                                         label = { Text(item.title) },
-                                        selected = selectedItem == index,
+                                        selected = currentDestinationId == item.destinationId(),
                                         onClick = {
-                                            selectedItem = index
                                             navController.navigate(item.path) {
                                                 popUpTo(navController.graph.startDestinationId) {
                                                     saveState = true
@@ -294,6 +301,15 @@ fun App(
                         }
                     )
                 }
+                animatedComposable<Portfolio> {
+                    PortfolioScreen(
+                        onConfigureClick = {
+                            navController.navigate(Settings) {
+                                launchSingleTop = true
+                            }
+                        }
+                    )
+                }
                 animatedComposable<Settings> {
                     SettingsScreen {
                         navController.popBackStack()
@@ -329,6 +345,15 @@ fun NetworkDialog() {
         },
         confirmButton = { /*no op*/ }
     )
+}
+
+/** Maps a bottom-bar [NavItem.Item] to its navigation destination id for route-based selection. */
+private fun NavItem.Item<*>.destinationId(): Int = when (this) {
+    NavItem.HomeScreen -> Market.serializer().generateHashCode()
+    NavItem.FavoritesScreen -> Favorites.serializer().generateHashCode()
+    NavItem.PortfolioScreen -> Portfolio.serializer().generateHashCode()
+    NavItem.SettingsScreen -> Settings.serializer().generateHashCode()
+    else -> -1
 }
 
 @OptIn(ExperimentalAnimationApi::class)

--- a/composeApp/src/commonMain/kotlin/model/NavItem.kt
+++ b/composeApp/src/commonMain/kotlin/model/NavItem.kt
@@ -1,6 +1,7 @@
 package model
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountBalanceWallet
 import androidx.compose.material.icons.filled.CandlestickChart
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
@@ -28,6 +29,12 @@ sealed class NavItem {
         title = "Favorites",
         icon = Icons.Default.Star
     )
+
+    object PortfolioScreen : Item<Portfolio>(
+        path = Portfolio,
+        title = "Portfolio",
+        icon = Icons.Default.AccountBalanceWallet
+    )
 }
 
 @Serializable
@@ -38,6 +45,9 @@ object Settings
 
 @Serializable
 object Favorites
+
+@Serializable
+object Portfolio
 
 @Serializable
 data class CoinDetail(val symbol: String, val displaySymbol: String)

--- a/composeApp/src/commonMain/kotlin/model/Portfolio.kt
+++ b/composeApp/src/commonMain/kotlin/model/Portfolio.kt
@@ -1,0 +1,150 @@
+package model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Hyperliquid portfolio models.
+ *
+ * The portfolio is read-only: it is derived entirely from a user's PUBLIC wallet
+ * address (a 0x… EVM address). No private key or API secret is required or stored.
+ *
+ * HTTP info endpoint: POST https://api.hyperliquid.xyz/info
+ *   - {"type":"clearinghouseState","user":"0x…"}      -> [HlPerpState]
+ *   - {"type":"spotClearinghouseState","user":"0x…"}  -> [HlSpotState]
+ *
+ * WebSocket: wss://api.hyperliquid.xyz/ws
+ *   - subscribe {"type":"webData3","user":"0x…"}  -> perps clearinghouseState (live)
+ *   - subscribe {"type":"spotState","user":"0x…"} -> spot balances (live)
+ *
+ * Every field has a default so partial/empty responses (and webData3 schema drift)
+ * never throw — the Json parser is configured with ignoreUnknownKeys = true.
+ */
+
+// region --- Raw API DTOs (perps) ---
+
+@Serializable
+data class HlMarginSummary(
+    @SerialName("accountValue") val accountValue: String = "0",
+    @SerialName("totalNtlPos") val totalNtlPos: String = "0",
+    @SerialName("totalRawUsd") val totalRawUsd: String = "0",
+    @SerialName("totalMarginUsed") val totalMarginUsed: String = "0",
+)
+
+@Serializable
+data class HlLeverage(
+    @SerialName("type") val type: String = "",   // "cross" | "isolated"
+    @SerialName("value") val value: Int = 0,
+)
+
+@Serializable
+data class HlPerpPosition(
+    @SerialName("coin") val coin: String = "",
+    @SerialName("szi") val szi: String = "0",            // signed size; leading "-" => short
+    @SerialName("entryPx") val entryPx: String? = null,
+    @SerialName("positionValue") val positionValue: String = "0",
+    @SerialName("unrealizedPnl") val unrealizedPnl: String = "0",
+    @SerialName("leverage") val leverage: HlLeverage = HlLeverage(),
+    @SerialName("liquidationPx") val liquidationPx: String? = null,
+    @SerialName("marginUsed") val marginUsed: String = "0",
+    @SerialName("returnOnEquity") val returnOnEquity: String = "0",
+)
+
+@Serializable
+data class HlAssetPosition(
+    @SerialName("type") val type: String = "",
+    @SerialName("position") val position: HlPerpPosition = HlPerpPosition(),
+)
+
+@Serializable
+data class HlPerpState(
+    @SerialName("marginSummary") val marginSummary: HlMarginSummary = HlMarginSummary(),
+    @SerialName("crossMarginSummary") val crossMarginSummary: HlMarginSummary = HlMarginSummary(),
+    @SerialName("withdrawable") val withdrawable: String = "0",
+    @SerialName("assetPositions") val assetPositions: List<HlAssetPosition> = emptyList(),
+    @SerialName("time") val time: Long = 0,
+)
+
+// endregion
+
+// region --- Raw API DTOs (spot) ---
+
+@Serializable
+data class HlSpotBalance(
+    @SerialName("coin") val coin: String = "",
+    @SerialName("token") val token: Int = 0,
+    @SerialName("total") val total: String = "0",
+    @SerialName("hold") val hold: String = "0",
+    @SerialName("entryNtl") val entryNtl: String? = null,
+)
+
+@Serializable
+data class HlSpotState(
+    @SerialName("balances") val balances: List<HlSpotBalance> = emptyList(),
+    @SerialName("time") val time: Long = 0,
+)
+
+// endregion
+
+// region --- UI / domain models consumed by the screen ---
+
+data class PortfolioSummary(
+    /** Best-effort total = perp equity + USD-stable spot value. */
+    val totalValue: Double,
+    val accountValue: Double,
+    val totalUnrealizedPnl: Double,
+    val totalMarginUsed: Double,
+    val withdrawable: Double,
+    /** Unrealized PnL as a % of cost-basis equity; null when not meaningful. */
+    val pnlPercent: Double?,
+)
+
+data class PerpPositionRow(
+    val coin: String,
+    val isLong: Boolean,
+    val size: Double,
+    val entryPx: Double?,
+    val markPx: Double?,
+    /** Absolute notional USD value of the position (for allocation). */
+    val notionalUsd: Double,
+    val unrealizedPnl: Double,
+    val roePercent: Double,
+    val leverageText: String,
+    val liquidationPx: Double?,
+    /** Distance from mark to liquidation as a fraction (0 = at liq, 1 = far); null if no liq. */
+    val liqDistanceFraction: Double?,
+    val marginUsed: Double,
+)
+
+data class SpotBalanceRow(
+    val coin: String,
+    val total: Double,
+    val available: Double,
+    val hold: Double,
+    /** USD value when known (stablecoins); null otherwise. */
+    val usdValue: Double?,
+)
+
+sealed interface PortfolioUiState {
+    /** Settings not yet loaded — transient. */
+    data object Loading : PortfolioUiState
+
+    /** No wallet address configured. */
+    data object NoAddress : PortfolioUiState
+
+    /** Configured address is not a valid 0x… EVM address. */
+    data object InvalidAddress : PortfolioUiState
+
+    /** Network/parse failure with no data to fall back on. */
+    data object Error : PortfolioUiState
+
+    data class Data(
+        val summary: PortfolioSummary,
+        val perpPositions: List<PerpPositionRow>,
+        val spotBalances: List<SpotBalanceRow>,
+        /** WebSocket dropped; showing last-known snapshot. */
+        val isStale: Boolean = false,
+    ) : PortfolioUiState
+}
+
+// endregion

--- a/composeApp/src/commonMain/kotlin/network/HyperliquidService.kt
+++ b/composeApp/src/commonMain/kotlin/network/HyperliquidService.kt
@@ -1,0 +1,100 @@
+package network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.serialization.json.Json
+import logging.AppLogger
+import model.HlPerpState
+import model.HlSpotState
+
+/**
+ * Read-only HTTP client for the Hyperliquid info endpoint.
+ *
+ * Used to fetch an immediate portfolio snapshot for a public wallet address while
+ * the live [PortfolioWebSocketService] connection is being established. Only the
+ * public 0x address is ever sent — there is no authentication.
+ */
+class HyperliquidService {
+    companion object {
+        private const val INFO_URL = "https://api.hyperliquid.xyz/info"
+        private const val MAX_RETRIES = 3
+    }
+
+    private val json = Json {
+        isLenient = true
+        ignoreUnknownKeys = true
+    }
+
+    private val rateLimiter = RateLimiter(maxRequests = 10, windowDurationMillis = 1000)
+
+    private val client = HttpClient {
+        install(HttpTimeout) {
+            connectTimeoutMillis = 15_000
+            socketTimeoutMillis = 30_000
+            requestTimeoutMillis = 30_000
+        }
+    }
+
+    fun close() {
+        client.close()
+    }
+
+    suspend fun fetchPerpState(user: String): HlPerpState? =
+        infoPost("clearinghouseState", user)?.let { body ->
+            runCatching { json.decodeFromString<HlPerpState>(body) }
+                .onFailure { AppLogger.logger.e(throwable = it) { "Hyperliquid: failed to parse clearinghouseState" } }
+                .getOrNull()
+        }
+
+    suspend fun fetchSpotState(user: String): HlSpotState? =
+        infoPost("spotClearinghouseState", user)?.let { body ->
+            runCatching { json.decodeFromString<HlSpotState>(body) }
+                .onFailure { AppLogger.logger.e(throwable = it) { "Hyperliquid: failed to parse spotClearinghouseState" } }
+                .getOrNull()
+        }
+
+    /**
+     * POST {"type":<type>,"user":<user>} to the info endpoint and return the raw body,
+     * or null on failure. The request body is built directly to avoid coupling to
+     * ContentNegotiation request serialization.
+     */
+    private suspend fun infoPost(type: String, user: String): String? {
+        val requestBody = """{"type":"$type","user":"$user"}"""
+        for (attempt in 0 until MAX_RETRIES) {
+            try {
+                rateLimiter.acquire()
+                val response: HttpResponse = client.post(INFO_URL) {
+                    contentType(ContentType.Application.Json)
+                    setBody(requestBody)
+                }
+                when {
+                    response.status == HttpStatusCode.OK -> return response.bodyAsText()
+                    response.status.value == 429 -> delay(1000L * (attempt + 1))      // rate limited
+                    response.status.value in 500..599 -> delay(500L * (attempt + 1))  // server error, back off
+                    else -> {
+                        AppLogger.logger.w { "Hyperliquid info ($type) returned ${response.status}" }
+                        return null
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                if (attempt == MAX_RETRIES - 1) {
+                    AppLogger.logger.e(throwable = e) { "Hyperliquid info ($type) request failed" }
+                    return null
+                }
+                delay(500L * (attempt + 1))
+            }
+        }
+        return null
+    }
+}

--- a/composeApp/src/commonMain/kotlin/network/PortfolioWebSocketService.kt
+++ b/composeApp/src/commonMain/kotlin/network/PortfolioWebSocketService.kt
@@ -1,0 +1,193 @@
+package network
+
+import getWebSocketClient
+import io.ktor.client.plugins.websocket.wss
+import io.ktor.client.request.header
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.websocket.Frame
+import io.ktor.websocket.readText
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import logging.AppLogger
+import model.HlPerpState
+import model.HlSpotState
+
+/**
+ * Real-time Hyperliquid portfolio stream for a public wallet address.
+ *
+ * Connects once to wss://api.hyperliquid.xyz/ws and subscribes to:
+ *   - webData3 -> perps clearinghouse state (nested under data.clearinghouseState)
+ *   - spotState -> spot balances
+ *
+ * Hyperliquid closes idle connections after 60s, so we send an application-level
+ * {"method":"ping"} text frame every [PING_INTERVAL_MS]. This is distinct from the
+ * WebSocket protocol ping/pong (server-initiated protocol pings are still answered).
+ *
+ * Mirrors the reconnect pattern of [TickerWebSocketService]: a supervised
+ * while(isActive) loop with a fixed backoff delay.
+ */
+class PortfolioWebSocketService {
+    companion object {
+        private const val WS_HOST = "api.hyperliquid.xyz"
+        private const val WS_PATH = "/ws"
+        private const val RECONNECTION_DELAY_MS = 3000L
+        private const val PING_INTERVAL_MS = 30_000L
+        private const val PING_MESSAGE = """{"method":"ping"}"""
+    }
+
+    private val webSocketClient = getWebSocketClient()
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    val perpState: StateFlow<HlPerpState?>
+        field = MutableStateFlow(null)
+
+    val spotState: StateFlow<HlSpotState?>
+        field = MutableStateFlow(null)
+
+    /** Non-null while the connection is down (drives a "reconnecting" / stale banner). */
+    val connectionError: StateFlow<String?>
+        field = MutableStateFlow(null)
+
+    private var webSocketJob: Job? = null
+    private var currentUser: String? = null
+    private var isConnected = false
+
+    fun connect(user: String) {
+        if (currentUser == user && isConnected) {
+            AppLogger.logger.d { "PortfolioWebSocket: already connected for $user" }
+            return
+        }
+
+        disconnect()
+        currentUser = user
+
+        webSocketJob = CoroutineScope(Dispatchers.Default).launch {
+            supervisorScope {
+                while (isActive) {
+                    try {
+                        AppLogger.logger.d { "PortfolioWebSocket: connecting for $user" }
+                        webSocketClient.wss(
+                            method = HttpMethod.Get,
+                            host = WS_HOST,
+                            path = WS_PATH,
+                            request = {
+                                header(HttpHeaders.ContentType, ContentType.Application.Json)
+                            }
+                        ) {
+                            isConnected = true
+                            connectionError.value = null
+
+                            // webData2 is a single atomic snapshot carrying BOTH the perps
+                            // clearinghouseState and spot balances (data.spotState.balances).
+                            // Using one source avoids two channels racing to overwrite each
+                            // other (which previously flickered the screen empty). webData3
+                            // buries perp data in a multi-dex array and isn't worth parsing.
+                            send(Frame.Text(subscribeFrame("webData2", user)))
+
+                            // Application-level heartbeat to defeat the 60s idle close.
+                            val pingJob = launch {
+                                while (isActive) {
+                                    delay(PING_INTERVAL_MS)
+                                    try {
+                                        send(Frame.Text(PING_MESSAGE))
+                                    } catch (e: Exception) {
+                                        break
+                                    }
+                                }
+                            }
+
+                            try {
+                                for (frame in incoming) {
+                                    if (!isActive) break
+                                    when (frame) {
+                                        is Frame.Text -> process(frame.readText())
+                                        is Frame.Ping -> send(Frame.Pong(frame.data))
+                                        is Frame.Close -> throw CancellationException("WebSocket closed")
+                                        else -> {}
+                                    }
+                                }
+                            } finally {
+                                pingJob.cancel()
+                            }
+                        }
+                        isConnected = false
+                    } catch (e: CancellationException) {
+                        isConnected = false
+                        break
+                    } catch (e: Exception) {
+                        isConnected = false
+                        if (isActive) {
+                            connectionError.value = e.message ?: "Connection lost"
+                            AppLogger.logger.e(throwable = e) { "PortfolioWebSocket: error for $user" }
+                            delay(RECONNECTION_DELAY_MS)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun subscribeFrame(type: String, user: String): String =
+        """{"method":"subscribe","subscription":{"type":"$type","user":"$user"}}"""
+
+    private fun process(text: String) {
+        try {
+            val root = json.parseToJsonElement(text).jsonObject
+            when (root["channel"]?.jsonPrimitive?.content) {
+                "pong" -> return // heartbeat ack
+                "webData2" -> {
+                    val data = root["data"]?.jsonObject ?: return
+                    // Perps clearinghouse state is nested under data.clearinghouseState; the
+                    // full spot snapshot under data.spotState ({ balances: [...] }).
+                    data["clearinghouseState"]?.let {
+                        perpState.value = json.decodeFromJsonElement(HlPerpState.serializer(), it)
+                    }
+                    data["spotState"]?.let { decodeSpot(it) }
+                }
+                else -> {} // subscriptionResponse, error, etc. — ignore
+            }
+        } catch (e: Exception) {
+            AppLogger.logger.e(throwable = e) { "PortfolioWebSocket: parse failed: ${text.take(200)}" }
+        }
+    }
+
+    private fun decodeSpot(element: JsonElement) {
+        runCatching {
+            spotState.value = json.decodeFromJsonElement(HlSpotState.serializer(), element)
+        }.onFailure {
+            AppLogger.logger.e(throwable = it) { "PortfolioWebSocket: failed to decode spot state" }
+        }
+    }
+
+    fun disconnect() {
+        webSocketJob?.cancel()
+        webSocketJob = null
+        isConnected = false
+        currentUser = null
+        perpState.value = null
+        spotState.value = null
+        connectionError.value = null
+        AppLogger.logger.d { "PortfolioWebSocket: disconnected" }
+    }
+
+    fun close() {
+        disconnect()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ui/PortfolioScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/PortfolioScreen.kt
@@ -1,0 +1,670 @@
+package ui
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountBalanceWallet
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.viewmodel.compose.viewModel
+import ktx.formatAsCurrency
+import model.PerpPositionRow
+import model.PortfolioSummary
+import model.PortfolioUiState
+import model.SpotBalanceRow
+import org.jetbrains.compose.resources.stringResource
+import theme.ThemeManager.store
+import ui.utils.getPriceChangeColor
+import ui.utils.isDarkTheme
+import utxo.composeapp.generated.resources.Res
+import utxo.composeapp.generated.resources.portfolio_account
+import utxo.composeapp.generated.resources.portfolio_allocation
+import utxo.composeapp.generated.resources.portfolio_available
+import utxo.composeapp.generated.resources.portfolio_away
+import utxo.composeapp.generated.resources.portfolio_empty
+import utxo.composeapp.generated.resources.portfolio_empty_hint
+import utxo.composeapp.generated.resources.portfolio_entry
+import utxo.composeapp.generated.resources.portfolio_free
+import utxo.composeapp.generated.resources.portfolio_hold
+import utxo.composeapp.generated.resources.portfolio_invalid_address
+import utxo.composeapp.generated.resources.portfolio_invalid_address_hint
+import utxo.composeapp.generated.resources.portfolio_liq
+import utxo.composeapp.generated.resources.portfolio_live
+import utxo.composeapp.generated.resources.portfolio_load_error
+import utxo.composeapp.generated.resources.portfolio_load_error_hint
+import utxo.composeapp.generated.resources.portfolio_long
+import utxo.composeapp.generated.resources.portfolio_margin_used
+import utxo.composeapp.generated.resources.portfolio_mark
+import utxo.composeapp.generated.resources.portfolio_no_address
+import utxo.composeapp.generated.resources.portfolio_no_address_hint
+import utxo.composeapp.generated.resources.portfolio_open_settings
+import utxo.composeapp.generated.resources.portfolio_positions
+import utxo.composeapp.generated.resources.portfolio_reconnecting
+import utxo.composeapp.generated.resources.portfolio_retry
+import utxo.composeapp.generated.resources.portfolio_short
+import utxo.composeapp.generated.resources.portfolio_size
+import utxo.composeapp.generated.resources.portfolio_spot
+import utxo.composeapp.generated.resources.portfolio_title
+import utxo.composeapp.generated.resources.portfolio_value
+import utxo.composeapp.generated.resources.refresh
+import kotlin.math.abs
+import kotlin.math.roundToLong
+
+/**
+ * Validates a Hyperliquid (EVM) wallet address: "0x" followed by 40 hex characters.
+ * Shared by the Settings input, the bottom-bar tab gate, and [PortfolioViewModel].
+ */
+fun isValidHyperliquidAddress(address: String): Boolean =
+    address.length == 42 &&
+        address.startsWith("0x") &&
+        address.drop(2).all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PortfolioScreen(
+    onConfigureClick: () -> Unit,
+    viewModel: PortfolioViewModel = viewModel { PortfolioViewModel() },
+) {
+    val state by viewModel.state.collectAsState()
+    val settings by store.updates.collectAsState(initial = null)
+    val isDark = isDarkTheme(settings)
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    // Pause the live socket when the screen is not visible (battery/data), resume on return.
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> viewModel.resume()
+                Lifecycle.Event.ON_PAUSE -> viewModel.pause()
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            viewModel.pause()
+        }
+    }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(stringResource(Res.string.portfolio_title)) },
+                actions = {
+                    IconButton(onClick = { viewModel.refresh() }) {
+                        Icon(Icons.Default.Refresh, contentDescription = stringResource(Res.string.refresh))
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Box(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+            when (val s = state) {
+                PortfolioUiState.Loading -> LoadingSkeleton()
+
+                PortfolioUiState.NoAddress -> InfoState(
+                    icon = Icons.Default.AccountBalanceWallet,
+                    title = stringResource(Res.string.portfolio_no_address),
+                    hint = stringResource(Res.string.portfolio_no_address_hint),
+                    actionText = stringResource(Res.string.portfolio_open_settings),
+                    onAction = onConfigureClick,
+                )
+
+                PortfolioUiState.InvalidAddress -> InfoState(
+                    icon = Icons.Default.ErrorOutline,
+                    title = stringResource(Res.string.portfolio_invalid_address),
+                    hint = stringResource(Res.string.portfolio_invalid_address_hint),
+                    actionText = stringResource(Res.string.portfolio_open_settings),
+                    onAction = onConfigureClick,
+                )
+
+                PortfolioUiState.Error -> InfoState(
+                    icon = Icons.Default.CloudOff,
+                    title = stringResource(Res.string.portfolio_load_error),
+                    hint = stringResource(Res.string.portfolio_load_error_hint),
+                    actionText = stringResource(Res.string.portfolio_retry),
+                    onAction = viewModel::refresh,
+                )
+
+                is PortfolioUiState.Data -> PortfolioContent(s, isDark)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PortfolioContent(data: PortfolioUiState.Data, isDark: Boolean) {
+    val palette = coinPalette()
+    val showPerpStats = data.perpPositions.isNotEmpty() || data.summary.accountValue > 0.0
+
+    // Allocation segments across USD-valued holdings (perp notionals + stable spot).
+    val allocation = buildList {
+        data.perpPositions.forEach { add(Triple(it.coin, it.notionalUsd, palette.colorFor(it.coin))) }
+        data.spotBalances.forEach { b -> b.usdValue?.let { add(Triple(b.coin, it, palette.colorFor(b.coin))) } }
+    }.filter { it.second > 0.0 }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        item(key = "hero") { HeroCard(data.summary, data.isStale, showPerpStats, isDark) }
+
+        if (allocation.size >= 2) {
+            item(key = "allocation") { AllocationStrip(allocation) }
+        }
+
+        if (data.perpPositions.isNotEmpty()) {
+            item(key = "perp_header") {
+                SectionHeader(stringResource(Res.string.portfolio_positions), data.perpPositions.size)
+            }
+            items(items = data.perpPositions, key = { "perp_${it.coin}" }) { row ->
+                PositionCard(row, palette.colorFor(row.coin), isDark)
+            }
+        }
+
+        if (data.spotBalances.isNotEmpty()) {
+            item(key = "spot_header") {
+                SectionHeader(stringResource(Res.string.portfolio_spot), data.spotBalances.size)
+            }
+            items(items = data.spotBalances, key = { "spot_${it.coin}" }) { row ->
+                SpotCard(row, palette.colorFor(row.coin))
+            }
+        }
+
+        if (data.perpPositions.isEmpty() && data.spotBalances.isEmpty()) {
+            item(key = "empty") { EmptyHoldings() }
+        }
+    }
+}
+
+// region --- Hero ---
+
+@Composable
+private fun HeroCard(summary: PortfolioSummary, isStale: Boolean, showPerpStats: Boolean, isDark: Boolean) {
+    val onHero = MaterialTheme.colorScheme.onPrimaryContainer
+    val sheen = Brush.linearGradient(
+        listOf(
+            MaterialTheme.colorScheme.primary.copy(alpha = 0.32f),
+            Color.Transparent,
+            MaterialTheme.colorScheme.tertiary.copy(alpha = 0.22f),
+        )
+    )
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(24.dp))
+            .background(MaterialTheme.colorScheme.primaryContainer)
+            .background(sheen)
+            .padding(20.dp)
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(Res.string.portfolio_value),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = onHero.copy(alpha = 0.75f),
+                )
+                LiveChip(isStale, onHero)
+            }
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text = summary.totalValue.toUsd(),
+                style = MaterialTheme.typography.headlineLarge,
+                fontWeight = FontWeight.Bold,
+                color = onHero,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (showPerpStats) {
+                Spacer(Modifier.height(10.dp))
+                PnlPill(summary.totalUnrealizedPnl, summary.pnlPercent, isDark)
+                Spacer(Modifier.height(18.dp))
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    HeroStat(stringResource(Res.string.portfolio_account), summary.accountValue.toUsd(), onHero, Modifier.weight(1f))
+                    HeroStat(stringResource(Res.string.portfolio_margin_used), summary.totalMarginUsed.toUsd(), onHero, Modifier.weight(1f))
+                    HeroStat(stringResource(Res.string.portfolio_free), summary.withdrawable.toUsd(), onHero, Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LiveChip(isStale: Boolean, onHero: Color) {
+    val dot = if (isStale) MaterialTheme.colorScheme.error else getPriceChangeColor(1f, isDarkTheme = false, primaryColor = onHero)
+    val label = if (isStale) stringResource(Res.string.portfolio_reconnecting) else stringResource(Res.string.portfolio_live)
+    Surface(
+        shape = RoundedCornerShape(50),
+        color = onHero.copy(alpha = 0.12f),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Box(Modifier.size(7.dp).clip(CircleShape).background(dot))
+            Text(label, style = MaterialTheme.typography.labelSmall, color = onHero)
+        }
+    }
+}
+
+@Composable
+private fun PnlPill(pnl: Double, pnlPercent: Double?, isDark: Boolean) {
+    val color = getPriceChangeColor(pnl.toFloat(), isDark, MaterialTheme.colorScheme.onPrimaryContainer)
+    val pct = pnlPercent?.let { " (${it.toSignedPercent()})" }.orEmpty()
+    Surface(shape = RoundedCornerShape(50), color = color.copy(alpha = 0.16f)) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Icon(
+                imageVector = if (pnl < 0) Icons.Default.ArrowDownward else Icons.Default.ArrowUpward,
+                contentDescription = null,
+                tint = color,
+                modifier = Modifier.size(16.dp),
+            )
+            Text(
+                text = pnl.toSignedUsd() + pct,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = color,
+            )
+        }
+    }
+}
+
+@Composable
+private fun HeroStat(label: String, value: String, onHero: Color, modifier: Modifier = Modifier) {
+    Column(modifier = modifier) {
+        Text(label, style = MaterialTheme.typography.labelSmall, color = onHero.copy(alpha = 0.7f), maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Text(value, style = MaterialTheme.typography.titleSmall, color = onHero, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    }
+}
+
+// endregion
+
+// region --- Allocation ---
+
+@Composable
+private fun AllocationStrip(items: List<Triple<String, Double, Color>>) {
+    val total = items.sumOf { it.second }
+    if (total <= 0.0) return
+    Column(modifier = Modifier.fillMaxWidth().padding(top = 4.dp)) {
+        Text(
+            text = stringResource(Res.string.portfolio_allocation),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(8.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(12.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+            horizontalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            items.forEach { (_, value, color) ->
+                Box(
+                    Modifier
+                        .weight((value / total).toFloat().coerceAtLeast(0.001f))
+                        .fillMaxHeight()
+                        .background(color),
+                )
+            }
+        }
+    }
+}
+
+// endregion
+
+// region --- Sections & rows ---
+
+@Composable
+private fun SectionHeader(title: String, count: Int) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(top = 4.dp, bottom = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        Surface(shape = CircleShape, color = MaterialTheme.colorScheme.primary.copy(alpha = 0.14f)) {
+            Text(
+                text = count.toString(),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PositionCard(row: PerpPositionRow, accent: Color, isDark: Boolean) {
+    val pnlColor = getPriceChangeColor(row.unrealizedPnl.toFloat(), isDark, MaterialTheme.colorScheme.onSurface)
+    Surface(
+        shape = RoundedCornerShape(18.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(14.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                CoinMonogram(row.coin, accent)
+                Spacer(Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                        Text(row.coin, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                        SidePill(row.isLong, isDark)
+                        if (row.leverageText.isNotBlank()) Tag(row.leverageText)
+                    }
+                    Spacer(Modifier.height(3.dp))
+                    Text(
+                        text = "${stringResource(Res.string.portfolio_size)} ${row.size.toAmount()}  ·  " +
+                            "${stringResource(Res.string.portfolio_entry)} ${row.entryPx.toPriceOrDash()}  ·  " +
+                            "${stringResource(Res.string.portfolio_mark)} ${row.markPx.toPriceOrDash()}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Column(horizontalAlignment = Alignment.End) {
+                    Text(row.unrealizedPnl.toSignedUsd(), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold, color = pnlColor)
+                    Text(row.roePercent.toSignedPercent(), style = MaterialTheme.typography.labelMedium, color = pnlColor)
+                }
+            }
+            if (row.liquidationPx != null && row.liqDistanceFraction != null && row.markPx != null) {
+                Spacer(Modifier.height(10.dp))
+                LiquidationBar(row.liqDistanceFraction, row.liquidationPx, row.markPx, isDark)
+            }
+        }
+    }
+}
+
+@Composable
+private fun LiquidationBar(fraction: Double, liqPx: Double, markPx: Double, isDark: Boolean) {
+    val safe = fraction.toFloat().coerceIn(0f, 1f)
+    // Healthy (far from liq) -> green, close -> red.
+    val barColor = getPriceChangeColor(if (safe > 0.35f) 1f else -1f, isDark, MaterialTheme.colorScheme.primary)
+    val awayPct = if (markPx != 0.0) abs(markPx - liqPx) / markPx * 100.0 else 0.0
+    Column {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(5.dp)
+                .clip(RoundedCornerShape(3.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+        ) {
+            Box(
+                Modifier
+                    .fillMaxWidth(safe)
+                    .fillMaxHeight()
+                    .background(barColor),
+            )
+        }
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = "${stringResource(Res.string.portfolio_liq)} ${liqPx.let { it.toPriceValue() }}  ·  ${awayPct.toAmount()}% ${stringResource(Res.string.portfolio_away)}",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun SpotCard(row: SpotBalanceRow, accent: Color) {
+    Surface(
+        shape = RoundedCornerShape(18.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            CoinMonogram(row.coin, accent)
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(row.coin, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                if (row.hold > 0.0) {
+                    Text(
+                        text = "${stringResource(Res.string.portfolio_available)} ${row.available.toAmount()}  ·  " +
+                            "${stringResource(Res.string.portfolio_hold)} ${row.hold.toAmount()}",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Column(horizontalAlignment = Alignment.End) {
+                Text(row.total.toAmount(), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
+                row.usdValue?.let {
+                    Text(it.toUsd(), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CoinMonogram(coin: String, accent: Color) {
+    Box(
+        modifier = Modifier.size(40.dp).clip(CircleShape).background(accent.copy(alpha = 0.18f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = coin.take(if (coin.length >= 2) 2 else 1).uppercase(),
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold,
+            color = accent,
+        )
+    }
+}
+
+@Composable
+private fun SidePill(isLong: Boolean, isDark: Boolean) {
+    val color = getPriceChangeColor(if (isLong) 1f else -1f, isDark, MaterialTheme.colorScheme.primary)
+    Surface(shape = RoundedCornerShape(50), color = color.copy(alpha = 0.16f)) {
+        Text(
+            text = if (isLong) stringResource(Res.string.portfolio_long) else stringResource(Res.string.portfolio_short),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = color,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+        )
+    }
+}
+
+@Composable
+private fun Tag(text: String) {
+    Surface(shape = RoundedCornerShape(50), color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.12f)) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+        )
+    }
+}
+
+// endregion
+
+// region --- States ---
+
+@Composable
+private fun EmptyHoldings() {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(stringResource(Res.string.portfolio_empty), style = MaterialTheme.typography.titleMedium, textAlign = TextAlign.Center)
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = stringResource(Res.string.portfolio_empty_hint),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+private fun InfoState(
+    icon: ImageVector,
+    title: String,
+    hint: String,
+    actionText: String,
+    onAction: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Box(
+            modifier = Modifier.size(72.dp).clip(CircleShape).background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(34.dp))
+        }
+        Spacer(Modifier.height(16.dp))
+        Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold, textAlign = TextAlign.Center)
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = hint,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(20.dp))
+        TextButton(onClick = onAction) { Text(actionText) }
+    }
+}
+
+@Composable
+private fun LoadingSkeleton() {
+    val transition = rememberInfiniteTransition(label = "shimmer")
+    val alpha by transition.animateFloat(
+        initialValue = 0.25f,
+        targetValue = 0.7f,
+        animationSpec = infiniteRepeatable(animation = tween(850), repeatMode = RepeatMode.Reverse),
+        label = "alpha",
+    )
+    val shimmer = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = alpha)
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Box(Modifier.fillMaxWidth().height(150.dp).clip(RoundedCornerShape(24.dp)).background(shimmer))
+        repeat(4) {
+            Box(Modifier.fillMaxWidth().height(72.dp).clip(RoundedCornerShape(18.dp)).background(shimmer))
+        }
+    }
+}
+
+// endregion
+
+// region --- colors & formatting ---
+
+private class CoinPalette(private val colors: List<Color>) {
+    fun colorFor(coin: String): Color = colors[(abs(coin.hashCode()) % colors.size)]
+}
+
+@Composable
+private fun coinPalette(): CoinPalette = CoinPalette(
+    listOf(
+        MaterialTheme.colorScheme.primary,
+        MaterialTheme.colorScheme.tertiary,
+        MaterialTheme.colorScheme.secondary,
+        getPriceChangeColor(1f, isDarkTheme = true, primaryColor = MaterialTheme.colorScheme.primary),
+        MaterialTheme.colorScheme.error,
+    )
+)
+
+private fun Double.toUsd(): String {
+    val formatted = abs(this).formatAsCurrency()
+    return if (this < 0) "-$$formatted" else "$$formatted"
+}
+
+private fun Double.toSignedUsd(): String {
+    val sign = if (this < 0) "-" else "+"
+    return "$sign$" + abs(this).formatAsCurrency()
+}
+
+private fun Double.toSignedPercent(): String {
+    val sign = if (this < 0) "-" else "+"
+    return "$sign${abs(this).toAmount()}%"
+}
+
+private fun Double.toPriceValue(): String =
+    if (abs(this) >= 1.0) "$" + this.formatAsCurrency() else "$" + this.toAmount()
+
+private fun Double?.toPriceOrDash(): String {
+    val v = this ?: return "—"
+    if (v == 0.0) return "—"
+    return v.toPriceValue()
+}
+
+private fun Double.toAmount(): String {
+    if (this == 0.0) return "0"
+    val rounded = (this * 1_000_000).roundToLong() / 1_000_000.0
+    val asLong = rounded.toLong()
+    return if (rounded == asLong.toDouble()) asLong.toString()
+    else rounded.toString().trimEnd('0').trimEnd('.')
+}
+
+// endregion

--- a/composeApp/src/commonMain/kotlin/ui/PortfolioScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/PortfolioScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -145,7 +146,10 @@ fun PortfolioScreen(
                     IconButton(onClick = { viewModel.refresh() }) {
                         Icon(Icons.Default.Refresh, contentDescription = stringResource(Res.string.refresh))
                     }
-                }
+                },
+                // The root Scaffold already applies the status-bar inset to this screen,
+                // so the nested top bar must not add it again (matches SettingsScreen).
+                windowInsets = WindowInsets(top = 0.dp, bottom = 0.dp),
             )
         }
     ) { innerPadding ->
@@ -459,7 +463,7 @@ private fun LiquidationBar(fraction: Double, liqPx: Double, markPx: Double, isDa
         }
         Spacer(Modifier.height(4.dp))
         Text(
-            text = "${stringResource(Res.string.portfolio_liq)} ${liqPx.let { it.toPriceValue() }}  ·  ${awayPct.toAmount()}% ${stringResource(Res.string.portfolio_away)}",
+            text = "${stringResource(Res.string.portfolio_liq)} ${liqPx.toPriceValue()}  ·  ${awayPct.toPercent(1)}% ${stringResource(Res.string.portfolio_away)}",
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -647,7 +651,16 @@ private fun Double.toSignedUsd(): String {
 
 private fun Double.toSignedPercent(): String {
     val sign = if (this < 0) "-" else "+"
-    return "$sign${abs(this).toAmount()}%"
+    return "$sign${abs(this).toPercent(2)}%"
+}
+
+/** Rounds to [decimals] places and trims trailing zeros (e.g. 18.50 -> "18.5", 18.00 -> "18"). */
+private fun Double.toPercent(decimals: Int): String {
+    val factor = if (decimals == 1) 10.0 else 100.0
+    val rounded = (this * factor).roundToLong() / factor
+    val asLong = rounded.toLong()
+    return if (rounded == asLong.toDouble()) asLong.toString()
+    else rounded.toString().trimEnd('0').trimEnd('.')
 }
 
 private fun Double.toPriceValue(): String =

--- a/composeApp/src/commonMain/kotlin/ui/PortfolioViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/ui/PortfolioViewModel.kt
@@ -1,0 +1,225 @@
+package ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import model.HlPerpPosition
+import model.HlPerpState
+import model.HlSpotBalance
+import model.HlSpotState
+import model.PerpPositionRow
+import model.PortfolioSummary
+import model.PortfolioUiState
+import model.SpotBalanceRow
+import network.HyperliquidService
+import network.PortfolioWebSocketService
+import theme.ThemeManager
+import kotlin.math.abs
+
+/**
+ * Drives the Portfolio screen for a single public Hyperliquid wallet address.
+ *
+ * The address is observed from the persisted [Settings] store rather than passed in,
+ * so editing it in Settings re-targets the live view without recreating the screen.
+ * On a valid address it fetches an immediate HTTP snapshot and opens the live
+ * WebSocket; the two raw sources are merged into a single [PortfolioUiState].
+ */
+class PortfolioViewModel : ViewModel() {
+    private val httpService = HyperliquidService()
+    private val wsService = PortfolioWebSocketService()
+    private val store = ThemeManager.store
+
+    private val addressFlow = MutableStateFlow<String?>(null) // null = settings not loaded yet
+    private val rawPerp = MutableStateFlow<HlPerpState?>(null)
+    private val rawSpot = MutableStateFlow<HlSpotState?>(null)
+    private val snapshotError = MutableStateFlow(false)
+
+    private var currentAddress: String? = null
+    private var snapshotJob: Job? = null
+
+    val state: StateFlow<PortfolioUiState> =
+        combine(
+            addressFlow,
+            rawPerp,
+            rawSpot,
+            snapshotError,
+            wsService.connectionError,
+        ) { addr, perp, spot, snapErr, wsErr ->
+            buildState(addr, perp, spot, snapErr, wsErr)
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, PortfolioUiState.Loading)
+
+    init {
+        // React to the saved wallet address changing in Settings.
+        viewModelScope.launch {
+            store.updates
+                .map { it?.hyperliquidWalletAddress?.trim().orEmpty() }
+                .distinctUntilChanged()
+                .collect { onAddressChanged(it) }
+        }
+        // Feed live WS updates into the raw flows (ignore the null resets a disconnect emits).
+        viewModelScope.launch { wsService.perpState.collect { if (it != null) rawPerp.value = it } }
+        viewModelScope.launch { wsService.spotState.collect { if (it != null) rawSpot.value = it } }
+    }
+
+    private fun onAddressChanged(addr: String) {
+        currentAddress = addr
+        addressFlow.value = addr
+        snapshotJob?.cancel()
+        rawPerp.value = null
+        rawSpot.value = null
+        snapshotError.value = false
+
+        if (!isValidHyperliquidAddress(addr)) {
+            wsService.disconnect()
+            return
+        }
+        loadSnapshot(addr)
+        wsService.connect(addr)
+    }
+
+    private fun loadSnapshot(addr: String) {
+        snapshotJob = viewModelScope.launch(Dispatchers.Default) {
+            val perp = httpService.fetchPerpState(addr)
+            val spot = httpService.fetchSpotState(addr)
+            withContext(Dispatchers.Main) {
+                if (perp == null && spot == null) {
+                    snapshotError.value = true
+                } else {
+                    snapshotError.value = false
+                    perp?.let { rawPerp.value = it }
+                    spot?.let { rawSpot.value = it }
+                }
+            }
+        }
+    }
+
+    /** Manual refresh (pull-to-refresh / retry). Live WS keeps the view fresh otherwise. */
+    fun refresh() {
+        currentAddress?.let { if (isValidHyperliquidAddress(it)) loadSnapshot(it) }
+    }
+
+    /** Screen became visible — (re)open the live connection. Safe to call repeatedly. */
+    fun resume() {
+        currentAddress?.let {
+            if (isValidHyperliquidAddress(it)) {
+                loadSnapshot(it)
+                wsService.connect(it)
+            }
+        }
+    }
+
+    /** Screen hidden — drop the socket to save battery/data; last-known data is kept. */
+    fun pause() {
+        wsService.disconnect()
+    }
+
+    private fun buildState(
+        addr: String?,
+        perp: HlPerpState?,
+        spot: HlSpotState?,
+        snapErr: Boolean,
+        wsErr: String?,
+    ): PortfolioUiState {
+        if (addr == null) return PortfolioUiState.Loading
+        if (addr.isBlank()) return PortfolioUiState.NoAddress
+        if (!isValidHyperliquidAddress(addr)) return PortfolioUiState.InvalidAddress
+        if (perp == null && spot == null) {
+            return if (snapErr) PortfolioUiState.Error else PortfolioUiState.Loading
+        }
+
+        val positions = perp?.assetPositions
+            ?.map { it.position }
+            ?.filter { it.coin.isNotBlank() && (it.szi.toDoubleOrNull() ?: 0.0) != 0.0 }
+            ?.map { it.toRow() }
+            ?.sortedByDescending { it.notionalUsd }
+            .orEmpty()
+
+        val balances = spot?.balances
+            ?.filter { (it.total.toDoubleOrNull() ?: 0.0) != 0.0 }
+            ?.map { it.toRow() }
+            ?.sortedByDescending { it.usdValue ?: 0.0 }
+            .orEmpty()
+
+        val accountValue = perp?.marginSummary?.accountValue?.toDoubleOrNull() ?: 0.0
+        val totalPnl = positions.sumOf { it.unrealizedPnl }
+        val spotUsd = balances.sumOf { it.usdValue ?: 0.0 }
+        val costBasis = accountValue - totalPnl
+        val summary = PortfolioSummary(
+            totalValue = accountValue + spotUsd,
+            accountValue = accountValue,
+            totalUnrealizedPnl = totalPnl,
+            totalMarginUsed = perp?.marginSummary?.totalMarginUsed?.toDoubleOrNull() ?: 0.0,
+            withdrawable = perp?.withdrawable?.toDoubleOrNull() ?: 0.0,
+            pnlPercent = if (costBasis > 0.0) totalPnl / costBasis * 100.0 else null,
+        )
+
+        return PortfolioUiState.Data(
+            summary = summary,
+            perpPositions = positions,
+            spotBalances = balances,
+            isStale = wsErr != null,
+        )
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        snapshotJob?.cancel()
+        wsService.close()
+        httpService.close()
+    }
+}
+
+/** Spot coins treated as $1 USD for best-effort valuation (no price feed needed). */
+private val STABLECOINS = setOf("USDC", "USDT", "USDT0", "USDE", "USDH", "USD1", "DAI", "USDB", "FDUSD")
+
+private fun HlPerpPosition.toRow(): PerpPositionRow {
+    val sziValue = szi.toDoubleOrNull() ?: 0.0
+    val sizeAbs = abs(sziValue)
+    val posValue = positionValue.toDoubleOrNull() ?: 0.0
+    val mark = if (sizeAbs != 0.0) posValue / sizeAbs else null
+    val entry = entryPx?.toDoubleOrNull()
+    val liq = liquidationPx?.toDoubleOrNull()
+    val roe = (returnOnEquity.toDoubleOrNull() ?: 0.0) * 100.0
+    // Health: how far mark is from liquidation, normalized against the entry→liq span.
+    val liqDistance = if (liq != null && mark != null && entry != null && entry != liq) {
+        ((mark - liq) / (entry - liq)).coerceIn(0.0, 1.0)
+    } else {
+        null
+    }
+    return PerpPositionRow(
+        coin = coin,
+        isLong = sziValue >= 0.0,
+        size = sizeAbs,
+        entryPx = entry,
+        markPx = mark,
+        notionalUsd = abs(posValue),
+        unrealizedPnl = unrealizedPnl.toDoubleOrNull() ?: 0.0,
+        roePercent = roe,
+        leverageText = if (leverage.value > 0) "${leverage.value}x ${leverage.type}".trim() else leverage.type,
+        liquidationPx = liq,
+        liqDistanceFraction = liqDistance,
+        marginUsed = marginUsed.toDoubleOrNull() ?: 0.0,
+    )
+}
+
+private fun HlSpotBalance.toRow(): SpotBalanceRow {
+    val totalValue = total.toDoubleOrNull() ?: 0.0
+    val holdValue = hold.toDoubleOrNull() ?: 0.0
+    return SpotBalanceRow(
+        coin = coin,
+        total = totalValue,
+        available = (totalValue - holdValue).coerceAtLeast(0.0),
+        hold = holdValue,
+        usdValue = if (coin.uppercase() in STABLECOINS) totalValue else null,
+    )
+}

--- a/composeApp/src/commonMain/kotlin/ui/PortfolioViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/ui/PortfolioViewModel.kt
@@ -145,8 +145,12 @@ class PortfolioViewModel : ViewModel() {
             .orEmpty()
 
         val balances = spot?.balances
-            ?.filter { (it.total.toDoubleOrNull() ?: 0.0) != 0.0 }
             ?.map { it.toRow() }
+            // Drop fully on-hold stablecoins: that USDC is perp collateral already
+            // counted in accountValue (webData2 reports it as 0; the HTTP spot endpoint
+            // returns it on-hold). usdValue is 0 only for a stablecoin with no available
+            // balance; non-stable tokens keep a null usdValue and stay visible.
+            ?.filter { it.total > 0.0 && it.usdValue != 0.0 }
             ?.sortedByDescending { it.usdValue ?: 0.0 }
             .orEmpty()
 
@@ -215,11 +219,14 @@ private fun HlPerpPosition.toRow(): PerpPositionRow {
 private fun HlSpotBalance.toRow(): SpotBalanceRow {
     val totalValue = total.toDoubleOrNull() ?: 0.0
     val holdValue = hold.toDoubleOrNull() ?: 0.0
+    val availableValue = (totalValue - holdValue).coerceAtLeast(0.0)
     return SpotBalanceRow(
         coin = coin,
         total = totalValue,
-        available = (totalValue - holdValue).coerceAtLeast(0.0),
+        available = availableValue,
         hold = holdValue,
-        usdValue = if (coin.uppercase() in STABLECOINS) totalValue else null,
+        // Value stablecoins by their AVAILABLE (free) balance — on-hold USDC is perp
+        // collateral already reflected in accountValue, so counting total double-counts it.
+        usdValue = if (coin.uppercase() in STABLECOINS) availableValue else null,
     )
 }

--- a/composeApp/src/commonMain/kotlin/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/SettingsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Article
 import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Palette
@@ -30,6 +31,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -72,10 +74,16 @@ import utxo.composeapp.generated.resources.settings_appearance
 import utxo.composeapp.generated.resources.settings_dark_mode
 import utxo.composeapp.generated.resources.settings_deselect_all
 import utxo.composeapp.generated.resources.settings_done
+import utxo.composeapp.generated.resources.settings_clear
 import utxo.composeapp.generated.resources.settings_github
+import utxo.composeapp.generated.resources.settings_hyperliquid_address
+import utxo.composeapp.generated.resources.settings_hyperliquid_address_hint
+import utxo.composeapp.generated.resources.settings_hyperliquid_invalid
 import utxo.composeapp.generated.resources.settings_news_sources
 import utxo.composeapp.generated.resources.settings_no_sources_enabled
+import utxo.composeapp.generated.resources.settings_portfolio
 import utxo.composeapp.generated.resources.settings_privacy_policy
+import utxo.composeapp.generated.resources.settings_save
 import utxo.composeapp.generated.resources.settings_select_all
 import utxo.composeapp.generated.resources.settings_select_news_sources
 import utxo.composeapp.generated.resources.settings_select_theme
@@ -172,6 +180,29 @@ fun SettingsScreen(
                         title = stringResource(Res.string.settings_news_sources),
                         subtitle = subtitle,
                         onClick = { showRssProvidersDialog = true }
+                    )
+                }
+
+                item {
+                    SettingsHeader(title = stringResource(Res.string.settings_portfolio))
+                    PortfolioAddressItem(
+                        savedAddress = settingsState?.hyperliquidWalletAddress.orEmpty(),
+                        onSave = { newAddress ->
+                            coroutineScope.launch {
+                                store.update { currentSettings ->
+                                    currentSettings?.copy(hyperliquidWalletAddress = newAddress)
+                                        ?: Settings(hyperliquidWalletAddress = newAddress)
+                                }
+                            }
+                        },
+                        onClear = {
+                            coroutineScope.launch {
+                                store.update { currentSettings ->
+                                    currentSettings?.copy(hyperliquidWalletAddress = "")
+                                        ?: Settings()
+                                }
+                            }
+                        }
                     )
                 }
 
@@ -350,6 +381,64 @@ private fun SettingsSwitchItem(
     }
 }
 
+
+@Composable
+private fun PortfolioAddressItem(
+    savedAddress: String,
+    onSave: (String) -> Unit,
+    onClear: () -> Unit
+) {
+    var text by remember(savedAddress) { mutableStateOf(savedAddress) }
+    val isValid = isValidHyperliquidAddress(text)
+    val isEmpty = text.isEmpty()
+    val isDirty = text != savedAddress
+    val showError = text.isNotEmpty() && !isValid
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        OutlinedTextField(
+            value = text,
+            onValueChange = { text = it.trim() },
+            label = { Text(stringResource(Res.string.settings_hyperliquid_address)) },
+            placeholder = { Text(stringResource(Res.string.settings_hyperliquid_address_hint)) },
+            singleLine = true,
+            isError = showError,
+            trailingIcon = {
+                if (text.isNotEmpty()) {
+                    IconButton(onClick = {
+                        text = ""
+                        onClear()
+                    }) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = stringResource(Res.string.settings_clear)
+                        )
+                    }
+                }
+            },
+            supportingText = if (showError) {
+                { Text(stringResource(Res.string.settings_hyperliquid_invalid)) }
+            } else {
+                null
+            },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End
+        ) {
+            TextButton(
+                onClick = { onSave(text) },
+                enabled = isDirty && (isValid || isEmpty)
+            ) {
+                Text(stringResource(Res.string.settings_save))
+            }
+        }
+    }
+}
 
 @Composable
 private fun ThemeSelectionDialog(
@@ -538,7 +627,8 @@ data class Settings(
     val appTheme: AppTheme = AppTheme.System,
     val favPairs: List<String> = listOf(""),
     val selectedTradingPair: String = "BTC",
-    val enabledRssProviders: Set<String> = RssProvider.DEFAULT_ENABLED_PROVIDERS
+    val enabledRssProviders: Set<String> = RssProvider.DEFAULT_ENABLED_PROVIDERS,
+    val hyperliquidWalletAddress: String = ""
 )
 
 enum class AppTheme {


### PR DESCRIPTION
## Description
Adds a **read-only** portfolio feature for Hyperliquid. The user enters their **public** `0x…` wallet address in Settings and the app shows their account portfolio updating in real time. No private keys or API secrets are collected or stored — Hyperliquid's info/websocket APIs return full portfolio data from the public address alone.

A **Portfolio** tab appears in the bottom navigation bar only when a valid address is configured.

**Real-time data (hybrid):** an instant HTTP `/info` snapshot for immediate display, then a live `webData2` WebSocket stream (a single atomic source carrying both perps `clearinghouseState` and spot balances) with a 30s app-level `{"method":"ping"}` heartbeat and auto-reconnect.

## Data correctness (verified against the live API)
- **No flicker:** message shapes were captured from the live socket. The dedicated `spotState` channel nests balances at `data.spotState.balances`; decoding `data` directly produced an empty state that raced `webData2`. Collapsed to a single atomic `webData2` source — structurally cannot flicker.
- **No collateral double-counting:** for accounts that use spot USDC as perp collateral, the HTTP spot endpoint returns that USDC fully on-hold while `webData2` reports it as `0`. Stablecoins are now valued by their **available** (`total − hold`) balance and fully on-hold stablecoins are dropped, so the HTTP snapshot and the live feed agree and the portfolio total is not doubled on refresh.

## UI
A redesigned screen (senior design pass): gradient hero card (true portfolio value, live indicator, PnL pill), allocation strip, position cards with coin monogram / long-short pill / leverage / liquidation-health bar, spot cards, shimmer loading and empty/error/no-address states. Plus polish fixes: removed a duplicated status-bar inset on the top bar and rounded percentages (PnL/ROE 2 dp, liquidation distance 1 dp).

## Changes Made
- `model/Portfolio.kt` — Hyperliquid `@Serializable` DTOs (defaulted fields, drift-tolerant), UI domain models, `PortfolioUiState`.
- `network/HyperliquidService.kt` — rate-limited HTTP `POST /info` snapshot (`clearinghouseState` + `spotClearinghouseState`).
- `network/PortfolioWebSocketService.kt` — live `webData2` stream with heartbeat + supervised reconnect (mirrors `TickerWebSocketService`).
- `ui/PortfolioViewModel.kt` — observes the saved address, merges snapshot + live, available-based stablecoin valuation, lifecycle pause/resume, `onCleared()` cleanup.
- `ui/PortfolioScreen.kt` — redesigned UI + inset/percent fixes.
- `ui/SettingsScreen.kt` — wallet-address input with validation + clear; new `hyperliquidWalletAddress` field on the persisted `Settings` (KStore) model.
- `model/NavItem.kt`, `App.kt` — conditional Portfolio tab; replaced brittle **index-based** bottom-bar selection with **route-based** selection.
- `strings.xml` — portfolio + settings strings.

## Type of Change
- [x] New feature
- [x] Bug fix (flicker, collateral double-count, top-inset, percent precision)

## Testing Done
- [x] Compiles clean on `compileKotlinDesktop` and `compileKotlinWasmJs` (full `commonMain` type-check across JVM + JS backends)
- [x] HTTP + WebSocket message shapes verified against the live Hyperliquid API for real accounts (spot-only, positions-rich, and a spot-as-collateral account)
- [x] Manual testing on iOS simulator (flicker, double-count, and layout fixes confirmed against live data)
- [ ] Unit tests (follow-up: `isValidHyperliquidAddress`, row mapping, `buildState`)

## Checklist
- [x] Material3 `colorScheme`, `stringResource`, StateFlow/`stateIn`, `expect`/`actual` reuse
- [x] No hardcoded colors or strings in the feature UI
- [x] No secrets stored — public address only, read-only
- [x] No breaking changes (new `Settings` field is additive with a default)

## Known follow-ups
- Web (wasmJs) CORS for `api.hyperliquid.xyz` unverified.
- Spot valuation is stablecoin-only (non-stable tokens listed without USD).
- Open orders / recent fills deferred from v1.

## Commits
- `feat(portfolio): add real-time Hyperliquid portfolio`
- `fix(portfolio): correct collateral double-count, top inset, percent precision`