### PR TITLE
[FEATURE] Track multiple Hyperliquid wallets with ENS labels and an aggregate view

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -123,6 +123,14 @@
     <string name="settings_hyperliquid_invalid">Must be 0x followed by 40 hex characters</string>
     <string name="settings_save">Save</string>
     <string name="settings_clear">Clear</string>
+    <string name="settings_add_wallet">Add wallet</string>
+    <string name="settings_wallet_limit">Maximum of %1$d wallets reached</string>
+    <string name="settings_duplicate_address">This wallet is already added</string>
+    <string name="settings_rename_wallet">Rename wallet</string>
+    <string name="settings_wallet_name">Wallet name</string>
+    <string name="settings_wallet_name_hint">Leave blank to use the ENS name or address</string>
+    <string name="settings_wallet_ens_badge">ENS</string>
+    <string name="settings_delete">Delete</string>
 
     <!-- Portfolio Screen -->
     <string name="portfolio_title">Portfolio</string>
@@ -161,4 +169,5 @@
     <string name="portfolio_size">Size</string>
     <string name="portfolio_away">away</string>
     <string name="portfolio_allocation">Allocation</string>
+    <string name="portfolio_all">All</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -60,7 +60,8 @@ import ui.CryptoViewModel
 import ui.FavoritesListScreen
 import ui.PortfolioScreen
 import ui.SettingsScreen
-import ui.isValidHyperliquidAddress
+import ui.hasPortfolioWallets
+import theme.ThemeManager
 import ui.utils.isDarkTheme
 import utxo.composeapp.generated.resources.Res
 import utxo.composeapp.generated.resources.network_unavailable
@@ -73,6 +74,12 @@ fun App(
     // Initialize logger early to ensure it's ready
     LaunchedEffect(Unit) {
         AppLogger.logger.d { "App initialized" }
+    }
+
+    // One-time migration of the legacy single Hyperliquid address into the wallet list.
+    // Runs here (not in the Portfolio VM, whose tab is gated on wallet presence).
+    LaunchedEffect(Unit) {
+        ThemeManager.migrateSettingsIfNeeded()
     }
     
     val navController: NavHostController = rememberNavController()
@@ -203,11 +210,11 @@ fun App(
         }
     }
 
-    // If the wallet address is cleared/invalidated while the user is on the Portfolio
-    // tab, the tab disappears — redirect to Market so they aren't stranded.
-    LaunchedEffect(currentDestinationId, settingsState?.hyperliquidWalletAddress) {
+    // If all tracked wallets are cleared while the user is on the Portfolio tab, the tab
+    // disappears — redirect to Market so they aren't stranded.
+    LaunchedEffect(currentDestinationId, settingsState?.hyperliquidWallets) {
         val onPortfolio = currentDestinationId == Portfolio.serializer().generateHashCode()
-        val enabled = isValidHyperliquidAddress(settingsState?.hyperliquidWalletAddress.orEmpty())
+        val enabled = settingsState?.hasPortfolioWallets() == true
         if (onPortfolio && !enabled) {
             navController.navigate(Market) {
                 popUpTo(navController.graph.startDestinationId) { saveState = true }
@@ -229,9 +236,7 @@ fun App(
                 if (!isCoinDetail) {
                     BottomAppBar(
                         actions = {
-                            val portfolioEnabled = isValidHyperliquidAddress(
-                                settingsState?.hyperliquidWalletAddress.orEmpty()
-                            )
+                            val portfolioEnabled = settingsState?.hasPortfolioWallets() == true
                             val navItems = buildList {
                                 add(NavItem.HomeScreen)
                                 add(NavItem.FavoritesScreen)

--- a/composeApp/src/commonMain/kotlin/model/Portfolio.kt
+++ b/composeApp/src/commonMain/kotlin/model/Portfolio.kt
@@ -21,6 +21,53 @@ import kotlinx.serialization.Serializable
  * never throw — the Json parser is configured with ignoreUnknownKeys = true.
  */
 
+// region --- Multi-wallet config ---
+
+/** Persisted scope sentinel: the aggregate "All wallets" view. Never a valid 0x address. */
+const val SCOPE_ALL = "all"
+
+/** Hard cap on tracked wallets — bounds simultaneous WebSockets and the shared rate limiter. */
+const val MAX_WALLETS = 5
+
+/**
+ * Validates a Hyperliquid (EVM) wallet address: "0x" followed by 40 hex characters.
+ * Lives in [model] so it can be shared downward by network/ui without a layer cycle;
+ * used by the Settings input, the bottom-bar tab gate, [network] ENS lookups, and the
+ * Portfolio ViewModel.
+ */
+fun isValidHyperliquidAddress(address: String): Boolean =
+    address.length == 42 &&
+        address.startsWith("0x") &&
+        address.drop(2).all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' }
+
+/**
+ * A single tracked Hyperliquid wallet. The portfolio is read-only — only the public
+ * [address] is ever used. [address] is stored lowercased so it is the canonical identity
+ * (dedup and scope-matching are plain `==`).
+ */
+@Serializable
+data class HyperliquidWallet(
+    val address: String,
+    /** User-set manual override; wins over [ensName]. */
+    val customLabel: String? = null,
+    /** Cached ENS reverse-resolution (.eth) name; null when none/unresolved. */
+    val ensName: String? = null,
+    /** When ENS was last resolved (epoch millis); null = never attempted. Drives the TTL. */
+    val ensResolvedAtMillis: Long? = null,
+)
+
+/** Display precedence: manual label, then ENS name, then a truncated address. */
+fun HyperliquidWallet.displayName(): String =
+    customLabel?.takeIf { it.isNotBlank() }
+        ?: ensName?.takeIf { it.isNotBlank() }
+        ?: shortenAddress(address)
+
+/** "0x1234…cdef" — first 6 + ellipsis + last 4. Returns the input unchanged if too short. */
+fun shortenAddress(addr: String): String =
+    if (addr.length >= 12) "${addr.take(6)}…${addr.takeLast(4)}" else addr
+
+// endregion
+
 // region --- Raw API DTOs (perps) ---
 
 @Serializable
@@ -114,6 +161,8 @@ data class PerpPositionRow(
     /** Distance from mark to liquidation as a fraction (0 = at liq, 1 = far); null if no liq. */
     val liqDistanceFraction: Double?,
     val marginUsed: Double,
+    /** Owning wallet's display name; non-null only in the aggregate "All" view. */
+    val sourceLabel: String? = null,
 )
 
 data class SpotBalanceRow(
@@ -123,6 +172,8 @@ data class SpotBalanceRow(
     val hold: Double,
     /** USD value when known (stablecoins); null otherwise. */
     val usdValue: Double?,
+    /** Owning wallet's display name; non-null only in the aggregate "All" view. */
+    val sourceLabel: String? = null,
 )
 
 sealed interface PortfolioUiState {
@@ -146,5 +197,29 @@ sealed interface PortfolioUiState {
         val isStale: Boolean = false,
     ) : PortfolioUiState
 }
+
+/**
+ * One wallet's fully-derived portfolio (post spot/stablecoin filtering). Aggregation must
+ * combine these — never raw DTOs — so cross-margin USDC is not double-counted.
+ */
+data class WalletData(
+    val address: String,
+    val summary: PortfolioSummary,
+    val perps: List<PerpPositionRow>,
+    val spot: List<SpotBalanceRow>,
+    /** Cost-basis equity used to blend an aggregate PnL %. */
+    val costBasis: Double,
+    /** True once a snapshot or live frame has produced real data. */
+    val hasData: Boolean,
+    val snapshotError: Boolean,
+    val isStale: Boolean,
+)
+
+/** A chip in the Portfolio scope switcher. [key] is [SCOPE_ALL] or a wallet address. */
+data class WalletTab(
+    val key: String,
+    val label: String,
+    val isStale: Boolean,
+)
 
 // endregion

--- a/composeApp/src/commonMain/kotlin/network/EnsService.kt
+++ b/composeApp/src/commonMain/kotlin/network/EnsService.kt
@@ -1,0 +1,90 @@
+package network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import logging.AppLogger
+import model.isValidHyperliquidAddress
+
+/**
+ * Read-only ENS reverse resolution for EVM addresses (Hyperliquid wallets are standard EVM
+ * addresses). Maps a public 0x address to its primary ENS (.eth) name, used only to label
+ * wallets. No key/auth; only the public address is sent.
+ *
+ * Endpoint: GET https://api.ensideas.com/ens/resolve/{address} — a free, no-key, CORS-enabled
+ * resolver that returns `{ "address", "name", "displayName", "avatar" }`. `name` is the
+ * primary ENS name or null when the address has none (in which case `displayName` is just a
+ * truncated address, which we ignore).
+ */
+class EnsService {
+    companion object {
+        private const val RESOLVE_URL = "https://api.ensideas.com/ens/resolve/"
+    }
+
+    private val json = Json {
+        isLenient = true
+        ignoreUnknownKeys = true
+    }
+
+    private val rateLimiter = RateLimiter(maxRequests = 5, windowDurationMillis = 1000)
+
+    private val client = HttpClient {
+        install(HttpTimeout) {
+            connectTimeoutMillis = 10_000
+            socketTimeoutMillis = 15_000
+            requestTimeoutMillis = 15_000
+        }
+    }
+
+    @Serializable
+    private data class EnsResponse(
+        @SerialName("name") val name: String? = null,
+    )
+
+    /**
+     * Resolve [address] to its primary ENS name.
+     *
+     * Returns [EnsResult.Resolved] (name possibly null = "no ENS") only when the HTTP call
+     * completed (200); any non-200 or network/parse failure yields [EnsResult.Failed] so the
+     * caller can avoid stamping a resolution timestamp and retry in a later session.
+     * Rethrows [CancellationException].
+     */
+    suspend fun resolveName(address: String): EnsResult {
+        if (!isValidHyperliquidAddress(address)) return EnsResult.Failed
+        return try {
+            rateLimiter.acquire()
+            val response: HttpResponse = client.get(RESOLVE_URL + address)
+            if (response.status == HttpStatusCode.OK) {
+                val parsed = runCatching { json.decodeFromString<EnsResponse>(response.bodyAsText()) }.getOrNull()
+                EnsResult.Resolved(parsed?.name?.trim()?.takeIf { it.isNotEmpty() })
+            } else {
+                EnsResult.Failed
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            AppLogger.logger.e(throwable = e) { "ENS: resolve failed for $address" }
+            EnsResult.Failed
+        }
+    }
+
+    fun close() {
+        client.close()
+    }
+}
+
+/** Outcome of an ENS lookup; distinguishes a completed call (cacheable) from a failure (retry). */
+sealed interface EnsResult {
+    /** HTTP completed; [name] is the primary ENS name or null when the address has none. */
+    data class Resolved(val name: String?) : EnsResult
+
+    /** Network/HTTP/parse failure — do not cache; retry later. */
+    data object Failed : EnsResult
+}

--- a/composeApp/src/commonMain/kotlin/theme/UTXOTheme.kt
+++ b/composeApp/src/commonMain/kotlin/theme/UTXOTheme.kt
@@ -6,6 +6,9 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import getKStore
+import model.HyperliquidWallet
+import model.SCOPE_ALL
+import model.isValidHyperliquidAddress
 import ui.AppTheme
 import ui.Settings
 
@@ -107,5 +110,31 @@ object ThemeManager {
 
     suspend fun updateTheme(newTheme: AppTheme) {
         store.update { it?.copy(appTheme = newTheme) ?: Settings(appTheme = newTheme) }
+    }
+
+    /**
+     * One-time migration of the legacy single [Settings.hyperliquidWalletAddress] into the
+     * [Settings.hyperliquidWallets] list. Idempotent (re-running is a no-op once the list is
+     * seeded / the legacy field is blanked) and safe to call on every launch. Runs from
+     * `App()` rather than the Portfolio ViewModel, whose tab is gated on wallet presence —
+     * a legacy-only user would otherwise never trigger it.
+     */
+    @Suppress("DEPRECATION")
+    suspend fun migrateSettingsIfNeeded() {
+        store.update { current ->
+            val s = current ?: return@update current
+            val legacy = s.hyperliquidWalletAddress.trim()
+            when {
+                s.hyperliquidWallets.isEmpty() && isValidHyperliquidAddress(legacy) ->
+                    s.copy(
+                        hyperliquidWallets = listOf(HyperliquidWallet(address = legacy.lowercase())),
+                        hyperliquidWalletAddress = "",
+                        portfolioScope = SCOPE_ALL,
+                    )
+                legacy.isNotEmpty() && s.hyperliquidWallets.isNotEmpty() ->
+                    s.copy(hyperliquidWalletAddress = "") // already migrated; just clean up
+                else -> current
+            }
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/ui/PortfolioScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/PortfolioScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -33,6 +34,7 @@ import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -62,13 +64,16 @@ import ktx.formatAsCurrency
 import model.PerpPositionRow
 import model.PortfolioSummary
 import model.PortfolioUiState
+import model.SCOPE_ALL
 import model.SpotBalanceRow
+import model.WalletTab
 import org.jetbrains.compose.resources.stringResource
 import theme.ThemeManager.store
 import ui.utils.getPriceChangeColor
 import ui.utils.isDarkTheme
 import utxo.composeapp.generated.resources.Res
 import utxo.composeapp.generated.resources.portfolio_account
+import utxo.composeapp.generated.resources.portfolio_all
 import utxo.composeapp.generated.resources.portfolio_allocation
 import utxo.composeapp.generated.resources.portfolio_available
 import utxo.composeapp.generated.resources.portfolio_away
@@ -101,15 +106,6 @@ import utxo.composeapp.generated.resources.refresh
 import kotlin.math.abs
 import kotlin.math.roundToLong
 
-/**
- * Validates a Hyperliquid (EVM) wallet address: "0x" followed by 40 hex characters.
- * Shared by the Settings input, the bottom-bar tab gate, and [PortfolioViewModel].
- */
-fun isValidHyperliquidAddress(address: String): Boolean =
-    address.length == 42 &&
-        address.startsWith("0x") &&
-        address.drop(2).all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' }
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PortfolioScreen(
@@ -117,6 +113,8 @@ fun PortfolioScreen(
     viewModel: PortfolioViewModel = viewModel { PortfolioViewModel() },
 ) {
     val state by viewModel.state.collectAsState()
+    val walletTabs by viewModel.walletTabs.collectAsState()
+    val selectedScope by viewModel.selectedScope.collectAsState()
     val settings by store.updates.collectAsState(initial = null)
     val isDark = isDarkTheme(settings)
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -153,9 +151,22 @@ fun PortfolioScreen(
             )
         }
     ) { innerPadding ->
-        Box(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
-            when (val s = state) {
-                PortfolioUiState.Loading -> LoadingSkeleton()
+        Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+            // The switcher is pinned above the body and stays visible in every state, so the
+            // user can switch away from a wallet that is loading or errored. Only shown with
+            // 2+ wallets (tabs = "All" + one per wallet), so a single wallet keeps the
+            // original switcher-free layout.
+            if (walletTabs.size > 2) {
+                WalletScopeSwitcher(
+                    tabs = walletTabs,
+                    selectedKey = selectedScope,
+                    onSelect = viewModel::selectScope,
+                    isDark = isDark,
+                )
+            }
+            Box(modifier = Modifier.fillMaxWidth().weight(1f)) {
+                when (val s = state) {
+                    PortfolioUiState.Loading -> LoadingSkeleton()
 
                 PortfolioUiState.NoAddress -> InfoState(
                     icon = Icons.Default.AccountBalanceWallet,
@@ -181,8 +192,43 @@ fun PortfolioScreen(
                     onAction = viewModel::refresh,
                 )
 
-                is PortfolioUiState.Data -> PortfolioContent(s, isDark)
+                    is PortfolioUiState.Data -> PortfolioContent(s, isDark)
+                }
             }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun WalletScopeSwitcher(
+    tabs: List<WalletTab>,
+    selectedKey: String,
+    onSelect: (String) -> Unit,
+    isDark: Boolean,
+) {
+    LazyRow(
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        items(items = tabs, key = { it.key }) { tab ->
+            val label = if (tab.key == SCOPE_ALL) stringResource(Res.string.portfolio_all) else tab.label
+            val dot = if (tab.isStale) {
+                MaterialTheme.colorScheme.error
+            } else {
+                getPriceChangeColor(1f, isDark, MaterialTheme.colorScheme.primary)
+            }
+            FilterChip(
+                selected = tab.key == selectedKey,
+                onClick = { onSelect(tab.key) },
+                label = {
+                    Text(label, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                },
+                leadingIcon = {
+                    Box(Modifier.size(8.dp).clip(CircleShape).background(dot))
+                },
+            )
         }
     }
 }
@@ -213,7 +259,7 @@ private fun PortfolioContent(data: PortfolioUiState.Data, isDark: Boolean) {
             item(key = "perp_header") {
                 SectionHeader(stringResource(Res.string.portfolio_positions), data.perpPositions.size)
             }
-            items(items = data.perpPositions, key = { "perp_${it.coin}" }) { row ->
+            items(items = data.perpPositions, key = { "perp_${it.sourceLabel}_${it.coin}" }) { row ->
                 PositionCard(row, palette.colorFor(row.coin), isDark)
             }
         }
@@ -222,7 +268,7 @@ private fun PortfolioContent(data: PortfolioUiState.Data, isDark: Boolean) {
             item(key = "spot_header") {
                 SectionHeader(stringResource(Res.string.portfolio_spot), data.spotBalances.size)
             }
-            items(items = data.spotBalances, key = { "spot_${it.coin}" }) { row ->
+            items(items = data.spotBalances, key = { "spot_${it.sourceLabel}_${it.coin}" }) { row ->
                 SpotCard(row, palette.colorFor(row.coin))
             }
         }
@@ -418,6 +464,7 @@ private fun PositionCard(row: PerpPositionRow, accent: Color, isDark: Boolean) {
                         SidePill(row.isLong, isDark)
                         if (row.leverageText.isNotBlank()) Tag(row.leverageText)
                     }
+                    row.sourceLabel?.let { WalletTagLine(it) }
                     Spacer(Modifier.height(3.dp))
                     Text(
                         text = "${stringResource(Res.string.portfolio_size)} ${row.size.toAmount()}  ·  " +
@@ -493,6 +540,7 @@ private fun SpotCard(row: SpotBalanceRow, accent: Color) {
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
+                row.sourceLabel?.let { WalletTagLine(it) }
             }
             Column(horizontalAlignment = Alignment.End) {
                 Text(row.total.toAmount(), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.SemiBold)
@@ -542,6 +590,33 @@ private fun Tag(text: String) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
         )
+    }
+}
+
+/** Small wallet-attribution pill shown on each row in the aggregate "All" view. */
+@Composable
+private fun WalletTagLine(label: String) {
+    Spacer(Modifier.height(3.dp))
+    Surface(shape = RoundedCornerShape(50), color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)) {
+        Row(
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.AccountBalanceWallet,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(11.dp),
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/ui/PortfolioViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/ui/PortfolioViewModel.kt
@@ -2,13 +2,19 @@ package ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -17,80 +23,279 @@ import model.HlPerpPosition
 import model.HlPerpState
 import model.HlSpotBalance
 import model.HlSpotState
+import model.HyperliquidWallet
+import model.MAX_WALLETS
 import model.PerpPositionRow
 import model.PortfolioSummary
 import model.PortfolioUiState
+import model.SCOPE_ALL
 import model.SpotBalanceRow
+import model.WalletData
+import model.WalletTab
+import model.displayName
+import model.isValidHyperliquidAddress
+import model.shortenAddress
+import network.EnsResult
+import network.EnsService
 import network.HyperliquidService
 import network.PortfolioWebSocketService
 import theme.ThemeManager
 import kotlin.math.abs
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 /**
- * Drives the Portfolio screen for a single public Hyperliquid wallet address.
+ * Drives the Portfolio screen for a set of public Hyperliquid wallet addresses.
  *
- * The address is observed from the persisted [Settings] store rather than passed in,
- * so editing it in Settings re-targets the live view without recreating the screen.
- * On a valid address it fetches an immediate HTTP snapshot and opens the live
- * WebSocket; the two raw sources are merged into a single [PortfolioUiState].
+ * The wallet list and the selected scope are observed from the persisted [Settings] store,
+ * so editing them in Settings re-targets the live view without recreating the screen. Each
+ * tracked wallet gets its own [WalletStream] (HTTP snapshot + live WebSocket); the per-wallet
+ * results are combined into either a single-wallet view or an aggregate "All" view depending
+ * on [selectedScope]. [walletTabs] and [selectedScope] are exposed independently of [state]
+ * so the scope switcher stays visible even while the body is Loading/Error.
  */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
 class PortfolioViewModel : ViewModel() {
-    private val httpService = HyperliquidService()
-    private val wsService = PortfolioWebSocketService()
+    private val httpService = HyperliquidService() // shared: one RateLimiter across all wallets
+    private val ensService = EnsService()
     private val store = ThemeManager.store
 
-    private val addressFlow = MutableStateFlow<String?>(null) // null = settings not loaded yet
-    private val rawPerp = MutableStateFlow<HlPerpState?>(null)
-    private val rawSpot = MutableStateFlow<HlSpotState?>(null)
-    private val snapshotError = MutableStateFlow(false)
+    /** Single-writer map of live streams (mutated only from the Main settings collector). */
+    private val streams = mutableMapOf<String, WalletStream>()
 
-    private var currentAddress: String? = null
-    private var snapshotJob: Job? = null
+    private val walletOrder = MutableStateFlow<List<String>>(emptyList())
+    private val walletsMeta = MutableStateFlow<List<HyperliquidWallet>>(emptyList())
+    private val selectedScopeState = MutableStateFlow(SCOPE_ALL)
+    private val settingsLoaded = MutableStateFlow(false)
+
+    /** True while the screen is visible — gates whether newly-added streams connect. */
+    private var isActive = false
+
+    /**
+     * Addresses already attempted in this VM instance (mutated only on Main, never removed).
+     * Covers both the in-flight window and completed attempts, so a failing ENS endpoint is
+     * not re-hit on every settings emission; a fresh VM (next app launch) retries.
+     */
+    private val attemptedEnsAddresses = mutableSetOf<String>()
+
+    val selectedScope: StateFlow<String> = selectedScopeState
 
     val state: StateFlow<PortfolioUiState> =
-        combine(
-            addressFlow,
-            rawPerp,
-            rawSpot,
-            snapshotError,
-            wsService.connectionError,
-        ) { addr, perp, spot, snapErr, wsErr ->
-            buildState(addr, perp, spot, snapErr, wsErr)
+        combine(walletOrder, selectedScopeState, walletsMeta, settingsLoaded) { order, scope, meta, loaded ->
+            StateInputs(order, scope, meta, loaded)
+        }.flatMapLatest { inp ->
+            if (inp.order.isEmpty()) {
+                flowOf(if (inp.loaded) PortfolioUiState.NoAddress else PortfolioUiState.Loading)
+            } else {
+                combine(inp.order.map { walletDataFlow(it) }) { it.toList() }
+                    .map { data -> assembleState(data, inp.scope, inp.meta) }
+            }
         }.stateIn(viewModelScope, SharingStarted.Eagerly, PortfolioUiState.Loading)
 
+    val walletTabs: StateFlow<List<WalletTab>> =
+        combine(walletOrder, walletsMeta) { order, meta -> order to meta }
+            .flatMapLatest { (order, meta) ->
+                if (order.isEmpty()) {
+                    flowOf(emptyList())
+                } else {
+                    combine(order.map { addr -> streamStaleFlow(addr) }) { staleArr ->
+                        buildList {
+                            // "All" chip: key is the sentinel; its label is resolved in the UI.
+                            add(WalletTab(SCOPE_ALL, "", staleArr.any { it }))
+                            order.forEachIndexed { i, addr ->
+                                val label = meta.find { it.address == addr }?.displayName() ?: shortenAddress(addr)
+                                add(WalletTab(addr, label, staleArr[i]))
+                            }
+                        }
+                    }
+                }
+            }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+
     init {
-        // React to the saved wallet address changing in Settings.
-        viewModelScope.launch {
-            store.updates
-                .map { it?.hyperliquidWalletAddress?.trim().orEmpty() }
-                .distinctUntilChanged()
-                .collect { onAddressChanged(it) }
+        // Single writer for the stream map + derived flows. Runs sequentially on Main.
+        viewModelScope.launch(Dispatchers.Main) {
+            store.updates.collect { settings ->
+                val wallets = settings?.hyperliquidWallets ?: emptyList()
+                walletsMeta.value = wallets
+                selectedScopeState.value = settings?.effectivePortfolioScope() ?: SCOPE_ALL
+                settingsLoaded.value = true
+
+                val desired = wallets.map { it.address.lowercase() }
+                    .filter { isValidHyperliquidAddress(it) }
+                    .distinct()
+                    .take(MAX_WALLETS)
+                if (desired != walletOrder.value) syncStreams(desired)
+
+                maybeResolveEns(wallets)
+            }
         }
+    }
+
+    /** Diff the stream map against [desired]; close removed, create+start added; emit new order. */
+    private fun syncStreams(desired: List<String>) {
+        (streams.keys - desired.toSet()).toList().forEach { addr ->
+            streams.remove(addr)?.close()
+        }
+        desired.forEach { addr ->
+            if (!streams.containsKey(addr)) {
+                val stream = WalletStream(addr, httpService, viewModelScope)
+                streams[addr] = stream
+                if (isActive) stream.resume()
+            }
+        }
+        walletOrder.value = desired // emit only after the map is populated (avoids a flatMapLatest race)
+    }
+
+    private fun walletDataFlow(address: String): Flow<WalletData> {
+        val s = streams[address] ?: return flowOf(emptyWalletData(address))
+        return combine(s.rawPerp, s.rawSpot, s.snapshotError, s.connectionError) { perp, spot, snapErr, wsErr ->
+            buildWalletData(address, perp, spot, snapErr, isStale = wsErr != null)
+        }
+    }
+
+    private fun streamStaleFlow(address: String): Flow<Boolean> =
+        streams[address]?.connectionError?.let { flow -> flow.map { it != null } } ?: flowOf(false)
+
+    /** Manual refresh (pull-to-refresh / retry) — re-fetch the HTTP snapshot for every wallet. */
+    fun refresh() {
+        streams.values.forEach { it.refresh() }
+    }
+
+    /** Persist the selected scope: [SCOPE_ALL] or a single wallet address. */
+    fun selectScope(scope: String) {
+        viewModelScope.launch { selectPortfolioScope(scope) }
+    }
+
+    /** Screen became visible — (re)open every wallet's live connection. */
+    fun resume() {
+        isActive = true
+        streams.values.forEach { it.resume() }
+    }
+
+    /** Screen hidden — drop sockets to save battery/data; last-known data is kept. */
+    fun pause() {
+        isActive = false
+        streams.values.forEach { it.pause() }
+    }
+
+    private fun assembleState(data: List<WalletData>, scope: String, meta: List<HyperliquidWallet>): PortfolioUiState {
+        if (scope != SCOPE_ALL) {
+            val wd = data.find { it.address == scope } ?: return PortfolioUiState.Loading
+            return assembleSingle(wd)
+        }
+        return aggregate(data, meta)
+    }
+
+    private fun assembleSingle(wd: WalletData): PortfolioUiState =
+        if (!wd.hasData) {
+            if (wd.snapshotError) PortfolioUiState.Error else PortfolioUiState.Loading
+        } else {
+            PortfolioUiState.Data(wd.summary, wd.perps, wd.spot, isStale = wd.isStale)
+        }
+
+    private fun aggregate(data: List<WalletData>, meta: List<HyperliquidWallet>): PortfolioUiState {
+        val withData = data.filter { it.hasData }
+        if (withData.isEmpty()) {
+            return if (data.isNotEmpty() && data.all { it.snapshotError }) {
+                PortfolioUiState.Error
+            } else {
+                PortfolioUiState.Loading
+            }
+        }
+        fun nameFor(addr: String) = meta.find { it.address == addr }?.displayName() ?: shortenAddress(addr)
+
+        val totalPnl = withData.sumOf { it.summary.totalUnrealizedPnl }
+        val costBasis = withData.sumOf { it.costBasis }
+        val summary = PortfolioSummary(
+            totalValue = withData.sumOf { it.summary.totalValue },
+            accountValue = withData.sumOf { it.summary.accountValue },
+            totalUnrealizedPnl = totalPnl,
+            totalMarginUsed = withData.sumOf { it.summary.totalMarginUsed },
+            withdrawable = withData.sumOf { it.summary.withdrawable },
+            // Blend by summed cost basis — never average percentages.
+            pnlPercent = if (costBasis > 0.0) totalPnl / costBasis * 100.0 else null,
+        )
+        val perps = withData
+            .flatMap { wd -> wd.perps.map { it.copy(sourceLabel = nameFor(wd.address)) } }
+            .sortedByDescending { it.notionalUsd }
+        val spot = withData
+            .flatMap { wd -> wd.spot.map { it.copy(sourceLabel = nameFor(wd.address)) } }
+            .sortedByDescending { it.usdValue ?: 0.0 }
+        // Stale if any wallet's socket is down, or some wallets haven't produced data yet.
+        val isStale = data.any { it.isStale } || withData.size < data.size
+        return PortfolioUiState.Data(summary, perps, spot, isStale = isStale)
+    }
+
+    /** Resolve ENS for wallets without a manual label and past the TTL; write the result back. */
+    private fun maybeResolveEns(wallets: List<HyperliquidWallet>) {
+        val now = Clock.System.now().toEpochMilliseconds()
+        wallets.forEach { w ->
+            if (w.customLabel != null) return@forEach
+            val resolvedAt = w.ensResolvedAtMillis
+            val due = resolvedAt == null || (now - resolvedAt) > ENS_TTL_MILLIS
+            if (!due) return@forEach
+            // Attempt each address at most once per VM instance (this runs on Main).
+            if (!attemptedEnsAddresses.add(w.address)) return@forEach
+            viewModelScope.launch(Dispatchers.Default) {
+                when (val result = ensService.resolveName(w.address)) {
+                    is EnsResult.Resolved -> cacheWalletEnsName(w.address, result.name, now)
+                    EnsResult.Failed -> Unit // leave un-stamped; a future app launch retries
+                }
+            }
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        streams.values.forEach { it.close() }
+        streams.clear()
+        ensService.close()
+        httpService.close()
+    }
+
+    private data class StateInputs(
+        val order: List<String>,
+        val scope: String,
+        val meta: List<HyperliquidWallet>,
+        val loaded: Boolean,
+    )
+
+    companion object {
+        private const val ENS_TTL_MILLIS = 7L * 24 * 60 * 60 * 1000
+    }
+}
+
+/**
+ * One wallet's live data source: an HTTP snapshot plus a dedicated [PortfolioWebSocketService].
+ * Owns a child [CoroutineScope] cancelled in [close] so its collectors don't leak when the
+ * wallet is removed mid-session.
+ */
+private class WalletStream(
+    val address: String,
+    private val httpService: HyperliquidService,
+    parent: CoroutineScope,
+) {
+    private val scope = CoroutineScope(parent.coroutineContext + SupervisorJob(parent.coroutineContext[Job]))
+    private val ws = PortfolioWebSocketService()
+
+    val rawPerp = MutableStateFlow<HlPerpState?>(null)
+    val rawSpot = MutableStateFlow<HlSpotState?>(null)
+    val snapshotError = MutableStateFlow(false)
+    val connectionError: StateFlow<String?> get() = ws.connectionError
+
+    private var snapshotJob: Job? = null
+
+    init {
         // Feed live WS updates into the raw flows (ignore the null resets a disconnect emits).
-        viewModelScope.launch { wsService.perpState.collect { if (it != null) rawPerp.value = it } }
-        viewModelScope.launch { wsService.spotState.collect { if (it != null) rawSpot.value = it } }
+        scope.launch { ws.perpState.collect { if (it != null) rawPerp.value = it } }
+        scope.launch { ws.spotState.collect { if (it != null) rawSpot.value = it } }
     }
 
-    private fun onAddressChanged(addr: String) {
-        currentAddress = addr
-        addressFlow.value = addr
+    private fun loadSnapshot() {
         snapshotJob?.cancel()
-        rawPerp.value = null
-        rawSpot.value = null
-        snapshotError.value = false
-
-        if (!isValidHyperliquidAddress(addr)) {
-            wsService.disconnect()
-            return
-        }
-        loadSnapshot(addr)
-        wsService.connect(addr)
-    }
-
-    private fun loadSnapshot(addr: String) {
-        snapshotJob = viewModelScope.launch(Dispatchers.Default) {
-            val perp = httpService.fetchPerpState(addr)
-            val spot = httpService.fetchSpotState(addr)
+        snapshotJob = scope.launch(Dispatchers.Default) {
+            val perp = httpService.fetchPerpState(address)
+            val spot = httpService.fetchSpotState(address)
             withContext(Dispatchers.Main) {
                 if (perp == null && spot == null) {
                     snapshotError.value = true
@@ -103,88 +308,84 @@ class PortfolioViewModel : ViewModel() {
         }
     }
 
-    /** Manual refresh (pull-to-refresh / retry). Live WS keeps the view fresh otherwise. */
-    fun refresh() {
-        currentAddress?.let { if (isValidHyperliquidAddress(it)) loadSnapshot(it) }
-    }
+    fun refresh() = loadSnapshot()
 
-    /** Screen became visible — (re)open the live connection. Safe to call repeatedly. */
     fun resume() {
-        currentAddress?.let {
-            if (isValidHyperliquidAddress(it)) {
-                loadSnapshot(it)
-                wsService.connect(it)
-            }
-        }
+        loadSnapshot()
+        ws.connect(address)
     }
 
-    /** Screen hidden — drop the socket to save battery/data; last-known data is kept. */
     fun pause() {
-        wsService.disconnect()
+        ws.disconnect()
     }
 
-    private fun buildState(
-        addr: String?,
-        perp: HlPerpState?,
-        spot: HlSpotState?,
-        snapErr: Boolean,
-        wsErr: String?,
-    ): PortfolioUiState {
-        if (addr == null) return PortfolioUiState.Loading
-        if (addr.isBlank()) return PortfolioUiState.NoAddress
-        if (!isValidHyperliquidAddress(addr)) return PortfolioUiState.InvalidAddress
-        if (perp == null && spot == null) {
-            return if (snapErr) PortfolioUiState.Error else PortfolioUiState.Loading
-        }
-
-        val positions = perp?.assetPositions
-            ?.map { it.position }
-            ?.filter { it.coin.isNotBlank() && (it.szi.toDoubleOrNull() ?: 0.0) != 0.0 }
-            ?.map { it.toRow() }
-            ?.sortedByDescending { it.notionalUsd }
-            .orEmpty()
-
-        val balances = spot?.balances
-            ?.map { it.toRow() }
-            // Drop fully on-hold stablecoins: that USDC is perp collateral already
-            // counted in accountValue (webData2 reports it as 0; the HTTP spot endpoint
-            // returns it on-hold). usdValue is 0 only for a stablecoin with no available
-            // balance; non-stable tokens keep a null usdValue and stay visible.
-            ?.filter { it.total > 0.0 && it.usdValue != 0.0 }
-            ?.sortedByDescending { it.usdValue ?: 0.0 }
-            .orEmpty()
-
-        val accountValue = perp?.marginSummary?.accountValue?.toDoubleOrNull() ?: 0.0
-        val totalPnl = positions.sumOf { it.unrealizedPnl }
-        val spotUsd = balances.sumOf { it.usdValue ?: 0.0 }
-        val costBasis = accountValue - totalPnl
-        val summary = PortfolioSummary(
-            totalValue = accountValue + spotUsd,
-            accountValue = accountValue,
-            totalUnrealizedPnl = totalPnl,
-            totalMarginUsed = perp?.marginSummary?.totalMarginUsed?.toDoubleOrNull() ?: 0.0,
-            withdrawable = perp?.withdrawable?.toDoubleOrNull() ?: 0.0,
-            pnlPercent = if (costBasis > 0.0) totalPnl / costBasis * 100.0 else null,
-        )
-
-        return PortfolioUiState.Data(
-            summary = summary,
-            perpPositions = positions,
-            spotBalances = balances,
-            isStale = wsErr != null,
-        )
-    }
-
-    override fun onCleared() {
-        super.onCleared()
+    fun close() {
         snapshotJob?.cancel()
-        wsService.close()
-        httpService.close()
+        ws.close()
+        scope.cancel()
     }
 }
 
 /** Spot coins treated as $1 USD for best-effort valuation (no price feed needed). */
 private val STABLECOINS = setOf("USDC", "USDT", "USDT0", "USDE", "USDH", "USD1", "DAI", "USDB", "FDUSD")
+
+private fun emptyWalletData(address: String): WalletData =
+    WalletData(
+        address = address,
+        summary = PortfolioSummary(0.0, 0.0, 0.0, 0.0, 0.0, null),
+        perps = emptyList(),
+        spot = emptyList(),
+        costBasis = 0.0,
+        hasData = false,
+        snapshotError = false,
+        isStale = false,
+    )
+
+private fun buildWalletData(
+    address: String,
+    perp: HlPerpState?,
+    spot: HlSpotState?,
+    snapErr: Boolean,
+    isStale: Boolean,
+): WalletData {
+    val positions = perp?.assetPositions
+        ?.map { it.position }
+        ?.filter { it.coin.isNotBlank() && (it.szi.toDoubleOrNull() ?: 0.0) != 0.0 }
+        ?.map { it.toRow() }
+        ?.sortedByDescending { it.notionalUsd }
+        .orEmpty()
+
+    val balances = spot?.balances
+        ?.map { it.toRow() }
+        // Drop fully on-hold stablecoins: that USDC is perp collateral already counted in
+        // accountValue (webData2 reports it as 0; the HTTP spot endpoint returns it on-hold).
+        ?.filter { it.total > 0.0 && it.usdValue != 0.0 }
+        ?.sortedByDescending { it.usdValue ?: 0.0 }
+        .orEmpty()
+
+    val accountValue = perp?.marginSummary?.accountValue?.toDoubleOrNull() ?: 0.0
+    val totalPnl = positions.sumOf { it.unrealizedPnl }
+    val spotUsd = balances.sumOf { it.usdValue ?: 0.0 }
+    val costBasis = accountValue - totalPnl
+    val summary = PortfolioSummary(
+        totalValue = accountValue + spotUsd,
+        accountValue = accountValue,
+        totalUnrealizedPnl = totalPnl,
+        totalMarginUsed = perp?.marginSummary?.totalMarginUsed?.toDoubleOrNull() ?: 0.0,
+        withdrawable = perp?.withdrawable?.toDoubleOrNull() ?: 0.0,
+        pnlPercent = if (costBasis > 0.0) totalPnl / costBasis * 100.0 else null,
+    )
+    return WalletData(
+        address = address,
+        summary = summary,
+        perps = positions,
+        spot = balances,
+        costBasis = costBasis,
+        hasData = perp != null || spot != null,
+        snapshotError = snapErr,
+        isStale = isStale,
+    )
+}
 
 private fun HlPerpPosition.toRow(): PerpPositionRow {
     val sziValue = szi.toDoubleOrNull() ?: 0.0
@@ -225,8 +426,8 @@ private fun HlSpotBalance.toRow(): SpotBalanceRow {
         total = totalValue,
         available = availableValue,
         hold = holdValue,
-        // Value stablecoins by their AVAILABLE (free) balance — on-hold USDC is perp
-        // collateral already reflected in accountValue, so counting total double-counts it.
+        // Value stablecoins by their AVAILABLE (free) balance — on-hold USDC is perp collateral
+        // already reflected in accountValue, so counting total double-counts it.
         usdValue = if (coin.uppercase() in STABLECOINS) availableValue else null,
     )
 }

--- a/composeApp/src/commonMain/kotlin/ui/PortfolioWalletStore.kt
+++ b/composeApp/src/commonMain/kotlin/ui/PortfolioWalletStore.kt
@@ -1,0 +1,99 @@
+package ui
+
+import model.HyperliquidWallet
+import model.MAX_WALLETS
+import model.SCOPE_ALL
+import model.isValidHyperliquidAddress
+import theme.ThemeManager
+
+/**
+ * Canonical, stateless mutations for the tracked Hyperliquid wallet list, shared by the
+ * Settings UI and [PortfolioViewModel]. Each is a plain `store.update` (mirrors
+ * [CryptoViewModel.addToFavorites]); callers launch them in their own scope.
+ *
+ * Addresses are canonicalised to lowercase so dedup and scope-matching are plain `==`.
+ * These intentionally do NOT call `syncSettingsToWidget` — wallet changes don't affect
+ * the favorites widget, so reloading its timeline would be wasted work.
+ */
+private val store get() = ThemeManager.store
+
+/** True when at least one tracked wallet is a valid address (gates the Portfolio tab). */
+fun Settings.hasPortfolioWallets(): Boolean =
+    hyperliquidWallets.any { isValidHyperliquidAddress(it.address) }
+
+/**
+ * Coerce a persisted scope to one that still exists: an unknown single-wallet scope (e.g.
+ * the selected wallet was deleted on another device) falls back to the aggregate view.
+ */
+fun Settings.effectivePortfolioScope(): String =
+    if (portfolioScope == SCOPE_ALL || hyperliquidWallets.any { it.address == portfolioScope }) {
+        portfolioScope
+    } else {
+        SCOPE_ALL
+    }
+
+/** Add a wallet. No-op when invalid, a duplicate, or the [MAX_WALLETS] cap is reached. */
+suspend fun addHyperliquidWallet(rawAddress: String) {
+    val addr = rawAddress.trim().lowercase()
+    if (!isValidHyperliquidAddress(addr)) return
+    store.update { current ->
+        val s = current ?: Settings()
+        val exists = s.hyperliquidWallets.any { it.address == addr }
+        if (exists || s.hyperliquidWallets.size >= MAX_WALLETS) {
+            s
+        } else {
+            s.copy(hyperliquidWallets = s.hyperliquidWallets + HyperliquidWallet(address = addr))
+        }
+    }
+}
+
+/** Set or clear a wallet's manual label (a blank label clears the override). */
+suspend fun renameHyperliquidWallet(address: String, label: String?) {
+    val addr = address.lowercase()
+    val clean = label?.trim()?.takeIf { it.isNotEmpty() }
+    store.update { current ->
+        val s = current ?: return@update current
+        s.copy(
+            hyperliquidWallets = s.hyperliquidWallets.map {
+                if (it.address == addr) it.copy(customLabel = clean) else it
+            },
+        )
+    }
+}
+
+/** Remove a wallet and heal the selected scope back to "All" if it pointed at this wallet. */
+suspend fun deleteHyperliquidWallet(address: String) {
+    val addr = address.lowercase()
+    store.update { current ->
+        val s = current ?: return@update current
+        s.copy(
+            hyperliquidWallets = s.hyperliquidWallets.filterNot { it.address == addr },
+            portfolioScope = if (s.portfolioScope == addr) SCOPE_ALL else s.portfolioScope,
+        )
+    }
+}
+
+/** Persist the selected scope: [SCOPE_ALL] or a single lowercased wallet address. */
+suspend fun selectPortfolioScope(scope: String) {
+    val normalized = if (scope == SCOPE_ALL) SCOPE_ALL else scope.lowercase()
+    store.update { current ->
+        val s = current ?: return@update current
+        if (s.portfolioScope == normalized) s else s.copy(portfolioScope = normalized)
+    }
+}
+
+/**
+ * Write back a resolved ENS name + resolution timestamp for a wallet. Stamp only after a
+ * completed HTTP call (even when [ensName] is null) so the TTL gate works; never touches
+ * [HyperliquidWallet.customLabel]. No-op when nothing changed.
+ */
+suspend fun cacheWalletEnsName(address: String, ensName: String?, nowMillis: Long) {
+    val addr = address.lowercase()
+    store.update { current ->
+        val s = current ?: return@update current
+        val updated = s.hyperliquidWallets.map {
+            if (it.address == addr) it.copy(ensName = ensName, ensResolvedAtMillis = nowMillis) else it
+        }
+        if (updated == s.hyperliquidWallets) s else s.copy(hyperliquidWallets = updated)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/SettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -20,6 +21,8 @@ import androidx.compose.material.icons.automirrored.filled.Article
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DarkMode
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Policy
@@ -52,11 +55,18 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
+import model.HyperliquidWallet
+import model.MAX_WALLETS
 import model.RssProvider
+import model.SCOPE_ALL
+import model.displayName
+import model.isValidHyperliquidAddress
+import model.shortenAddress
 import openLink
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
@@ -73,17 +83,23 @@ import utxo.composeapp.generated.resources.settings_all_sources_enabled
 import utxo.composeapp.generated.resources.settings_appearance
 import utxo.composeapp.generated.resources.settings_dark_mode
 import utxo.composeapp.generated.resources.settings_deselect_all
+import utxo.composeapp.generated.resources.settings_add_wallet
+import utxo.composeapp.generated.resources.settings_delete
 import utxo.composeapp.generated.resources.settings_done
-import utxo.composeapp.generated.resources.settings_clear
+import utxo.composeapp.generated.resources.settings_duplicate_address
 import utxo.composeapp.generated.resources.settings_github
-import utxo.composeapp.generated.resources.settings_hyperliquid_address
 import utxo.composeapp.generated.resources.settings_hyperliquid_address_hint
 import utxo.composeapp.generated.resources.settings_hyperliquid_invalid
 import utxo.composeapp.generated.resources.settings_news_sources
 import utxo.composeapp.generated.resources.settings_no_sources_enabled
 import utxo.composeapp.generated.resources.settings_portfolio
 import utxo.composeapp.generated.resources.settings_privacy_policy
+import utxo.composeapp.generated.resources.settings_rename_wallet
 import utxo.composeapp.generated.resources.settings_save
+import utxo.composeapp.generated.resources.settings_wallet_ens_badge
+import utxo.composeapp.generated.resources.settings_wallet_limit
+import utxo.composeapp.generated.resources.settings_wallet_name
+import utxo.composeapp.generated.resources.settings_wallet_name_hint
 import utxo.composeapp.generated.resources.settings_select_all
 import utxo.composeapp.generated.resources.settings_select_news_sources
 import utxo.composeapp.generated.resources.settings_select_theme
@@ -185,24 +201,13 @@ fun SettingsScreen(
 
                 item {
                     SettingsHeader(title = stringResource(Res.string.settings_portfolio))
-                    PortfolioAddressItem(
-                        savedAddress = settingsState?.hyperliquidWalletAddress.orEmpty(),
-                        onSave = { newAddress ->
-                            coroutineScope.launch {
-                                store.update { currentSettings ->
-                                    currentSettings?.copy(hyperliquidWalletAddress = newAddress)
-                                        ?: Settings(hyperliquidWalletAddress = newAddress)
-                                }
-                            }
+                    PortfolioWalletsManager(
+                        wallets = settingsState?.hyperliquidWallets ?: emptyList(),
+                        onAdd = { address -> coroutineScope.launch { addHyperliquidWallet(address) } },
+                        onRename = { address, label ->
+                            coroutineScope.launch { renameHyperliquidWallet(address, label) }
                         },
-                        onClear = {
-                            coroutineScope.launch {
-                                store.update { currentSettings ->
-                                    currentSettings?.copy(hyperliquidWalletAddress = "")
-                                        ?: Settings()
-                                }
-                            }
-                        }
+                        onDelete = { address -> coroutineScope.launch { deleteHyperliquidWallet(address) } },
                     )
                 }
 
@@ -383,61 +388,181 @@ private fun SettingsSwitchItem(
 
 
 @Composable
-private fun PortfolioAddressItem(
-    savedAddress: String,
-    onSave: (String) -> Unit,
-    onClear: () -> Unit
+private fun PortfolioWalletsManager(
+    wallets: List<HyperliquidWallet>,
+    onAdd: (String) -> Unit,
+    onRename: (String, String?) -> Unit,
+    onDelete: (String) -> Unit,
 ) {
-    var text by remember(savedAddress) { mutableStateOf(savedAddress) }
-    val isValid = isValidHyperliquidAddress(text)
-    val isEmpty = text.isEmpty()
-    val isDirty = text != savedAddress
-    val showError = text.isNotEmpty() && !isValid
+    var renameTarget by remember { mutableStateOf<HyperliquidWallet?>(null) }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        wallets.forEach { wallet ->
+            WalletRow(
+                wallet = wallet,
+                onRename = { renameTarget = wallet },
+                onDelete = { onDelete(wallet.address) },
+            )
+        }
+        AddWalletField(
+            existing = wallets,
+            atCap = wallets.size >= MAX_WALLETS,
+            onAdd = onAdd,
+        )
+    }
+
+    renameTarget?.let { target ->
+        RenameWalletDialog(
+            wallet = target,
+            onConfirm = { label ->
+                onRename(target.address, label)
+                renameTarget = null
+            },
+            onDismiss = { renameTarget = null },
+        )
+    }
+}
+
+@Composable
+private fun WalletRow(
+    wallet: HyperliquidWallet,
+    onRename: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                Text(
+                    text = wallet.displayName(),
+                    style = MaterialTheme.typography.bodyLarge,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (wallet.customLabel == null && wallet.ensName != null) {
+                    Surface(
+                        shape = RoundedCornerShape(50),
+                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.12f),
+                    ) {
+                        Text(
+                            text = stringResource(Res.string.settings_wallet_ens_badge),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 1.dp),
+                        )
+                    }
+                }
+            }
+            Text(
+                text = shortenAddress(wallet.address),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        IconButton(onClick = onRename) {
+            Icon(Icons.Default.Edit, contentDescription = stringResource(Res.string.settings_rename_wallet))
+        }
+        IconButton(onClick = onDelete) {
+            Icon(Icons.Default.Delete, contentDescription = stringResource(Res.string.settings_delete))
+        }
+    }
+}
+
+@Composable
+private fun AddWalletField(
+    existing: List<HyperliquidWallet>,
+    atCap: Boolean,
+    onAdd: (String) -> Unit,
+) {
+    var text by remember { mutableStateOf("") }
+    val normalized = text.trim().lowercase()
+    val isValid = isValidHyperliquidAddress(normalized)
+    val isDuplicate = isValid && existing.any { it.address == normalized }
+    val showError = text.isNotEmpty() && (!isValid || isDuplicate)
+    val canAdd = isValid && !isDuplicate && !atCap
 
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
     ) {
         OutlinedTextField(
             value = text,
             onValueChange = { text = it.trim() },
-            label = { Text(stringResource(Res.string.settings_hyperliquid_address)) },
+            label = { Text(stringResource(Res.string.settings_add_wallet)) },
             placeholder = { Text(stringResource(Res.string.settings_hyperliquid_address_hint)) },
             singleLine = true,
+            enabled = !atCap,
             isError = showError,
-            trailingIcon = {
-                if (text.isNotEmpty()) {
-                    IconButton(onClick = {
-                        text = ""
-                        onClear()
-                    }) {
-                        Icon(
-                            imageVector = Icons.Default.Close,
-                            contentDescription = stringResource(Res.string.settings_clear)
-                        )
-                    }
+            supportingText = when {
+                atCap -> {
+                    { Text(stringResource(Res.string.settings_wallet_limit, MAX_WALLETS)) }
                 }
+                isDuplicate -> {
+                    { Text(stringResource(Res.string.settings_duplicate_address)) }
+                }
+                showError -> {
+                    { Text(stringResource(Res.string.settings_hyperliquid_invalid)) }
+                }
+                else -> null
             },
-            supportingText = if (showError) {
-                { Text(stringResource(Res.string.settings_hyperliquid_invalid)) }
-            } else {
-                null
-            },
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
         )
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.End
+            horizontalArrangement = Arrangement.End,
         ) {
             TextButton(
-                onClick = { onSave(text) },
-                enabled = isDirty && (isValid || isEmpty)
+                onClick = {
+                    onAdd(normalized)
+                    text = ""
+                },
+                enabled = canAdd,
             ) {
-                Text(stringResource(Res.string.settings_save))
+                Text(stringResource(Res.string.settings_add_wallet))
             }
         }
     }
+}
+
+@Composable
+private fun RenameWalletDialog(
+    wallet: HyperliquidWallet,
+    onConfirm: (String?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var text by remember { mutableStateOf(wallet.customLabel.orEmpty()) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(Res.string.settings_rename_wallet)) },
+        text = {
+            OutlinedTextField(
+                value = text,
+                onValueChange = { text = it },
+                label = { Text(stringResource(Res.string.settings_wallet_name)) },
+                placeholder = { Text(stringResource(Res.string.settings_wallet_name_hint)) },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(text.trim().takeIf { it.isNotEmpty() }) }) {
+                Text(stringResource(Res.string.settings_save))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.cancel))
+            }
+        },
+    )
 }
 
 @Composable
@@ -628,7 +753,11 @@ data class Settings(
     val favPairs: List<String> = listOf(""),
     val selectedTradingPair: String = "BTC",
     val enabledRssProviders: Set<String> = RssProvider.DEFAULT_ENABLED_PROVIDERS,
-    val hyperliquidWalletAddress: String = ""
+    @Deprecated("Migrated into hyperliquidWallets; kept one release for migration read.")
+    val hyperliquidWalletAddress: String = "",
+    val hyperliquidWallets: List<HyperliquidWallet> = emptyList(),
+    /** [SCOPE_ALL] (aggregate) or a single lowercased wallet address. */
+    val portfolioScope: String = SCOPE_ALL,
 )
 
 enum class AppTheme {

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-versionName=0.4.2
-versionCode=42
+versionName=0.4.6
+versionCode=406


### PR DESCRIPTION
## Description
Replaces the single read-only Hyperliquid wallet address with support for tracking **multiple wallets** (up to 5), an aggregate **"All"** scope, optional **ENS** name labels, and per-wallet live data streams. Existing users are migrated automatically on launch.

## Changes Made
- **`model/Portfolio.kt`** — new `HyperliquidWallet`, `WalletData`, `WalletTab` models; `SCOPE_ALL` / `MAX_WALLETS` constants; `isValidHyperliquidAddress` / `displayName` / `shortenAddress` helpers (moved here to avoid a layer cycle). `PerpPositionRow` / `SpotBalanceRow` gain an optional `sourceLabel` for wallet attribution in the aggregate view.
- **`ui/PortfolioViewModel.kt`** — each tracked wallet gets a dedicated `WalletStream` (HTTP snapshot + `PortfolioWebSocketService`) on a child `CoroutineScope`. Streams are diffed against the persisted wallet list and combined into either a single-wallet view or a summed aggregate. `walletTabs` and `selectedScope` are exposed independently of `state` so the scope switcher stays visible while the body is loading/errored. Aggregate PnL% is blended by summed cost basis (never averaged percentages).
- **`ui/PortfolioWalletStore.kt`** (new) — canonical `add` / `rename` / `delete` / `selectScope` / `cacheWalletEnsName` mutations shared by Settings and the ViewModel; addresses canonicalised to lowercase for plain `==` dedup/scope-matching.
- **`network/EnsService.kt`** (new) — read-only ENS reverse resolution via `api.ensideas.com` (no key/auth, only the public address is sent) with a 7-day TTL cache and retry-on-failure semantics.
- **`ui/PortfolioScreen.kt`** — `WalletScopeSwitcher` filter chips (shown only with 2+ wallets) and per-row wallet attribution tags in the aggregate view; `LazyColumn` keys include `sourceLabel`.
- **`ui/SettingsScreen.kt`** — multi-wallet manager (add field with validation/dedup/cap, rename dialog, delete) replacing the single-address field. `Settings.hyperliquidWalletAddress` deprecated (kept one release for migration read); adds `hyperliquidWallets` and `portfolioScope`.
- **`theme/UTXOTheme.kt` + `App.kt`** — idempotent one-time launch migration of the legacy address into `hyperliquidWallets`; Portfolio tab gated on `hasPortfolioWallets()`.
- **`version.properties`** — bump to `0.4.6` (code `406`); new wallet-management strings in `strings.xml`.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance improvement

## Testing Done
- [ ] Unit tests added/updated
- [x] Manual testing on Android
- [ ] Manual testing on iOS (if applicable)
- [ ] Manual testing on Desktop (if applicable)

## Checklist
- [x] Code follows project style guidelines (`MaterialTheme.colorScheme.*`, `stringResource`, `StateFlow` + `collectAsState`, child-scope cleanup in `onCleared`)
- [x] Tests pass locally (CI runs build)
- [x] No breaking changes — legacy address auto-migrates; deprecated field retained one release

## Notes for Reviewers
- Read-only throughout: only public addresses are ever sent; ENS lookups carry no auth.
- `MAX_WALLETS = 5` bounds simultaneous WebSockets and shares one `RateLimiter` across wallets.
