### PR TITLE
[CHORE] Bump version to 0.4.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ keystore.properties
 play-sa.json
 *.play-sa.json
 androidApp/src/main/play/release-notes/
+androidApp/release/
 raw-screenshots/

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -439,7 +439,7 @@
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 47;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = 37UYJHD27F;
 				ENABLE_PREVIEWS = YES;
@@ -455,7 +455,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.6;
+				MARKETING_VERSION = 0.4.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = org.androdevlinux.utxo.UTXO;
 				PRODUCT_NAME = "${APP_NAME}";
@@ -473,7 +473,7 @@
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 47;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = 37UYJHD27F;
 				ENABLE_PREVIEWS = YES;
@@ -489,7 +489,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.6;
+				MARKETING_VERSION = 0.4.7;
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = org.androdevlinux.utxo.UTXO;
 				PRODUCT_NAME = "${APP_NAME}";

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-versionName=0.4.6
-versionCode=406
+versionName=0.4.7
+versionCode=407


### PR DESCRIPTION
## Description
Release version bump from **0.4.6 → 0.4.7**, keeping Android and iOS version metadata in sync. Also adds the Android release build output directory to `.gitignore` so generated artifacts (release APK, baseline profiles, metadata) aren't accidentally committed.

## Changes Made
- `version.properties` — `versionName` 0.4.6 → 0.4.7, `versionCode` 406 → 407
- `iosApp/iosApp.xcodeproj/project.pbxproj` — `MARKETING_VERSION` 0.4.6 → 0.4.7, `CURRENT_PROJECT_VERSION` 45 → 47 (both Debug and Release configs)
- `.gitignore` — ignore `androidApp/release/` build output

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [x] Chore / release versioning

## Testing Done
- [ ] Unit tests added/updated (n/a — metadata-only change)
- [ ] Manual testing on Android
- [ ] Manual testing on iOS (if applicable)
- [ ] Manual testing on Desktop (if applicable)

## Checklist
- [x] Code follows project style guidelines
- [x] No source code changed — version metadata only
- [x] No breaking changes
- [x] Build artifacts excluded from the commit

## Related Issues
N/A
