### PR TITLE
[FEATURE] iOS 26 Liquid Glass tab bar — content flows under the bar

### DIFF
--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -316,9 +316,9 @@ fun App(
                     )
                 }
                 animatedComposable<Settings> {
-                    SettingsScreen {
+                    SettingsScreen(onBackPress = {
                         navController.popBackStack()
-                    }
+                    })
                 }
                 composable<CoinDetail> { backStackEntry ->
                     val coinDetail = backStackEntry.toRoute<CoinDetail>()

--- a/composeApp/src/commonMain/kotlin/ui/CryptoListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/CryptoListScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -83,6 +84,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.Lifecycle
@@ -105,6 +107,7 @@ import theme.yellowDark
 import theme.yellowLight
 import ui.components.LazyColumnScrollbar
 import ui.components.ScrollToEdgeButton
+import ui.utils.bottomBarClearancePadding
 import ui.utils.calculateChartPoints
 import ui.utils.calculatePriceStats
 import ui.utils.createPriceChangeGradientColors
@@ -140,7 +143,10 @@ val LocalSettings = staticCompositionLocalOf<Settings?> { null }
 @Composable
 fun CryptoList(
     cryptoViewModel: CryptoViewModel,
-    onCoinClick: (String, String) -> Unit = { _, _ -> }
+    onCoinClick: (String, String) -> Unit = { _, _ -> },
+    // Bottom clearance for the iOS 26 native glass tab bar; 0.dp (no-op) on every other path. See
+    // ui.utils.bottomBarClearancePadding.
+    bottomBarClearance: Dp = 0.dp,
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
     val listState = rememberLazyListState()
@@ -391,7 +397,10 @@ fun CryptoList(
                                     Box(modifier = Modifier.fillMaxSize()) {
                                         LazyColumn(
                                             state = listState,
-                                            modifier = Modifier.fillMaxSize()
+                                            modifier = Modifier.fillMaxSize(),
+                                            contentPadding = PaddingValues(
+                                                bottom = bottomBarClearancePadding(bottomBarClearance),
+                                            ),
                                         ) {
                                             stickyHeader {
                                                 TickerCardListHeader(cryptoViewModel)
@@ -419,7 +428,8 @@ fun CryptoList(
                                         LazyColumnScrollbar(listState = listState)
                                         ScrollToEdgeButton(
                                             listState = listState,
-                                            totalItems = tickerItems.size
+                                            totalItems = tickerItems.size,
+                                            bottomBarClearance = bottomBarClearancePadding(bottomBarClearance),
                                         )
                                     }
                                 }
@@ -1041,7 +1051,10 @@ fun TickerCard(
 @Composable
 fun FavoritesListScreen(
     cryptoViewModel: CryptoViewModel,
-    onCoinClick: (String, String) -> Unit = { _, _ -> }
+    onCoinClick: (String, String) -> Unit = { _, _ -> },
+    // Bottom clearance for the iOS 26 native glass tab bar; 0.dp (no-op) on every other path. See
+    // ui.utils.bottomBarClearancePadding.
+    bottomBarClearance: Dp = 0.dp,
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
     val coroutineScope = rememberCoroutineScope()
@@ -1199,7 +1212,12 @@ fun FavoritesListScreen(
                 } else {
                     CompositionLocalProvider(LocalSettings provides settingsStore) {
                         Box(modifier = Modifier.fillMaxSize()) {
-                            LazyColumn(state = listState) {
+                            LazyColumn(
+                                state = listState,
+                                contentPadding = PaddingValues(
+                                    bottom = bottomBarClearancePadding(bottomBarClearance),
+                                ),
+                            ) {
                                 items(
                                     items = tickerItems,
                                     key = { it.symbol } // Stable key for efficient recomposition
@@ -1222,7 +1240,8 @@ fun FavoritesListScreen(
                             LazyColumnScrollbar(listState = listState)
                             ScrollToEdgeButton(
                                 listState = listState,
-                                totalItems = tickerItems.size
+                                totalItems = tickerItems.size,
+                                bottomBarClearance = bottomBarClearancePadding(bottomBarClearance),
                             )
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/ui/PortfolioScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/PortfolioScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -69,6 +70,7 @@ import model.SpotBalanceRow
 import model.WalletTab
 import org.jetbrains.compose.resources.stringResource
 import theme.ThemeManager.store
+import ui.utils.bottomBarClearancePadding
 import ui.utils.getPriceChangeColor
 import ui.utils.isDarkTheme
 import utxo.composeapp.generated.resources.Res
@@ -111,6 +113,11 @@ import kotlin.math.roundToLong
 fun PortfolioScreen(
     onConfigureClick: () -> Unit,
     viewModel: PortfolioViewModel = viewModel { PortfolioViewModel() },
+    // Bottom clearance for the iOS 26 native Liquid Glass tab bar. On that path the screen applies
+    // only the top window inset to its body so the list flows UNDER the bar (frosting through it),
+    // then reserves this footprint as the list's bottom contentPadding so the last card still scrolls
+    // clear. Defaults to 0.dp on every other path (App() reserves its own bottom bar) → no change.
+    bottomBarClearance: Dp = 0.dp,
 ) {
     val state by viewModel.state.collectAsState()
     val walletTabs by viewModel.walletTabs.collectAsState()
@@ -151,7 +158,19 @@ fun PortfolioScreen(
             )
         }
     ) { innerPadding ->
-        Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+        // The list flows under the iOS 26 glass tab bar; reserve the bar's footprint as bottom
+        // contentPadding so the last card still scrolls clear of it. No-op off the iOS 26 path
+        // (bottomBarClearance is 0). See ui.utils.bottomBarClearancePadding.
+        val extraBottom = bottomBarClearancePadding(bottomBarClearance)
+        // On the iOS 26 path apply only the top inset so the body reaches the screen bottom and the
+        // list flows UNDER the glass bar (extraBottom keeps the last card scrollable clear); off that
+        // path reserve the whole innerPadding exactly as before.
+        val bodyModifier = if (bottomBarClearance > 0.dp) {
+            Modifier.fillMaxSize().padding(top = innerPadding.calculateTopPadding())
+        } else {
+            Modifier.fillMaxSize().padding(innerPadding)
+        }
+        Column(modifier = bodyModifier) {
             // The switcher is pinned above the body and stays visible in every state, so the
             // user can switch away from a wallet that is loading or errored. Only shown with
             // 2+ wallets (tabs = "All" + one per wallet), so a single wallet keeps the
@@ -192,7 +211,7 @@ fun PortfolioScreen(
                     onAction = viewModel::refresh,
                 )
 
-                    is PortfolioUiState.Data -> PortfolioContent(s, isDark)
+                    is PortfolioUiState.Data -> PortfolioContent(s, isDark, extraBottom)
                 }
             }
         }
@@ -234,7 +253,7 @@ private fun WalletScopeSwitcher(
 }
 
 @Composable
-private fun PortfolioContent(data: PortfolioUiState.Data, isDark: Boolean) {
+private fun PortfolioContent(data: PortfolioUiState.Data, isDark: Boolean, extraBottomPadding: Dp) {
     val palette = coinPalette()
     val showPerpStats = data.perpPositions.isNotEmpty() || data.summary.accountValue > 0.0
 
@@ -246,7 +265,7 @@ private fun PortfolioContent(data: PortfolioUiState.Data, isDark: Boolean) {
 
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 24.dp),
+        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 24.dp + extraBottomPadding),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         item(key = "hero") { HeroCard(data.summary, data.isStale, showPerpStats, isDark) }

--- a/composeApp/src/commonMain/kotlin/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/SettingsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -56,6 +57,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
@@ -72,6 +74,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
 import theme.ThemeManager
 import theme.ThemeManager.store
+import ui.utils.bottomBarClearancePadding
 import ui.utils.debouncedClickable
 import ui.utils.isDarkTheme
 import utxo.composeapp.generated.resources.Res
@@ -117,7 +120,10 @@ import utxo.composeapp.generated.resources.theme_system
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
-    onBackPress: () -> Unit
+    onBackPress: () -> Unit,
+    // Bottom clearance for the iOS 26 native glass tab bar; 0.dp (no-op) on every other path. See
+    // ui.utils.bottomBarClearancePadding.
+    bottomBarClearance: Dp = 0.dp,
 ) {
     var showThemeDialog by remember { mutableStateOf(false) }
     var showRssProvidersDialog by remember { mutableStateOf(false) }
@@ -155,10 +161,22 @@ fun SettingsScreen(
             )
         }
     ) { innerPadding ->
+        // On the iOS 26 path apply only the top inset so the list reaches the screen bottom and flows
+        // UNDER the glass bar (the LazyColumn's bottom contentPadding keeps the last row scrollable
+        // clear); off that path reserve the whole innerPadding exactly as before.
+        val boxModifier = if (bottomBarClearance > 0.dp) {
+            Modifier.padding(top = innerPadding.calculateTopPadding())
+        } else {
+            Modifier.padding(innerPadding)
+        }
         Box(
-            modifier = Modifier.padding(innerPadding)
+            modifier = boxModifier
         ) {
-            LazyColumn {
+            LazyColumn(
+                contentPadding = PaddingValues(
+                    bottom = bottomBarClearancePadding(bottomBarClearance),
+                ),
+            ) {
                 item {
                     SettingsHeader(title = stringResource(Res.string.settings_appearance))
                     SettingsItem(

--- a/composeApp/src/commonMain/kotlin/ui/components/ScrollToEdgeButton.kt
+++ b/composeApp/src/commonMain/kotlin/ui/components/ScrollToEdgeButton.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
@@ -32,7 +33,10 @@ import utxo.composeapp.generated.resources.scroll_to_top
 fun BoxScope.ScrollToEdgeButton(
     listState: LazyListState,
     totalItems: Int,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    // Extra bottom offset so the FAB floats above the iOS 26 glass tab bar (the host Box extends
+    // under it). 0.dp on every other path; see ui.utils.bottomBarClearancePadding.
+    bottomBarClearance: Dp = 0.dp,
 ) {
     val scope = rememberCoroutineScope()
 
@@ -48,7 +52,7 @@ fun BoxScope.ScrollToEdgeButton(
         visible = visible,
         modifier = modifier
             .align(Alignment.BottomEnd)
-            .padding(end = 24.dp, bottom = 16.dp),
+            .padding(end = 24.dp, bottom = 16.dp + bottomBarClearance),
         enter = fadeIn() + scaleIn(),
         exit = fadeOut() + scaleOut()
     ) {

--- a/composeApp/src/commonMain/kotlin/ui/utils/BottomBarInsets.kt
+++ b/composeApp/src/commonMain/kotlin/ui/utils/BottomBarInsets.kt
@@ -1,0 +1,21 @@
+package ui.utils
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Bottom content padding that lets a scrolling list flow UNDER the iOS 26 native Liquid Glass tab
+ * bar — so the bar frosts the list content (Contacts-style) — while keeping the last item scrollable
+ * fully clear of the bar.
+ *
+ * On the iOS 26 native-TabView path each tab's Compose view extends edge-to-edge under the floating
+ * bar (via `.ignoresSafeArea(.container, edges: .bottom)` in LiquidGlassRootView.swift), and each
+ * screen applies only the TOP window inset to its body so the scroll viewport reaches the screen
+ * bottom. The bar's footprint is then reserved here as list `contentPadding.bottom` (NOT as parent
+ * padding, which would keep the viewport above the bar).
+ *
+ * [clearance] is that footprint, passed ONLY by the iOS-26 ComposeUIViewController hosts
+ * (MainViewController.kt). It defaults to 0.dp everywhere else (the shared App() path on
+ * Android / Desktop / Web / iOS < 26), making this a no-op so those platforms are unchanged.
+ */
+fun bottomBarClearancePadding(clearance: Dp): Dp = clearance.coerceAtLeast(0.dp)

--- a/composeApp/src/iosMain/kotlin/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/MainViewController.kt
@@ -2,6 +2,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ComposeUIViewController
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -59,19 +60,39 @@ private fun IosScreen(content: @Composable () -> Unit) {
 /** Full-Compose UI used as the fallback on iOS < 26 (keeps its own Compose bottom bar). */
 fun MainViewController(): UIViewController = ComposeUIViewController { App() }
 
+/**
+ * Footprint of the iOS 26 Liquid Glass tab bar (bar height + the home-indicator gap below it).
+ * Each tab's Compose view extends edge-to-edge under the floating bar (see
+ * LiquidGlassRootView.swift), so its scrolling content reserves this as bottom contentPadding to
+ * keep the last item scrollable clear of the bar while still flowing under the glass.
+ */
+private val NativeTabBarClearance = 90.dp
+
 fun MarketViewController(onCoin: (String, String) -> Unit): UIViewController =
-    ComposeUIViewController { IosScreen { CryptoList(IosShared.cryptoViewModel, onCoin) } }
+    ComposeUIViewController {
+        IosScreen { CryptoList(IosShared.cryptoViewModel, onCoin, bottomBarClearance = NativeTabBarClearance) }
+    }
 
 fun FavoritesViewController(onCoin: (String, String) -> Unit): UIViewController =
-    ComposeUIViewController { IosScreen { FavoritesListScreen(IosShared.cryptoViewModel, onCoin) } }
+    ComposeUIViewController {
+        IosScreen { FavoritesListScreen(IosShared.cryptoViewModel, onCoin, bottomBarClearance = NativeTabBarClearance) }
+    }
 
 fun SettingsViewController(): UIViewController =
-    ComposeUIViewController { IosScreen { SettingsScreen(onBackPress = {}) } }
+    ComposeUIViewController {
+        IosScreen { SettingsScreen(onBackPress = {}, bottomBarClearance = NativeTabBarClearance) }
+    }
 
 /** Portfolio screen for the iOS 26 native-TabView path. [onConfigure] should select Settings. */
 fun PortfolioViewController(onConfigure: () -> Unit): UIViewController =
     ComposeUIViewController {
-        IosScreen { PortfolioScreen(onConfigureClick = onConfigure, viewModel = IosShared.portfolioViewModel) }
+        IosScreen {
+            PortfolioScreen(
+                onConfigureClick = onConfigure,
+                viewModel = IosShared.portfolioViewModel,
+                bottomBarClearance = NativeTabBarClearance,
+            )
+        }
     }
 
 fun CoinDetailViewController(

--- a/iosApp/iosApp/LiquidGlassRootView.swift
+++ b/iosApp/iosApp/LiquidGlassRootView.swift
@@ -24,6 +24,9 @@ struct LiquidGlassRootView: View {
                         marketPath.append(CoinRoute(symbol: symbol, display: display))
                     }
                     .ignoresSafeArea(.keyboard)
+                    // Extend Compose under the floating glass tab bar so the list frosts through it
+                    // (Contacts-style). Bottom only — the top status-bar inset must be preserved.
+                    .ignoresSafeArea(.container, edges: .bottom)
                     .toolbar(.hidden, for: .navigationBar)
                     .navigationDestination(for: CoinRoute.self) { route in
                         detail(route) { marketPath.removeLast() }
@@ -37,6 +40,7 @@ struct LiquidGlassRootView: View {
                         favPath.append(CoinRoute(symbol: symbol, display: display))
                     }
                     .ignoresSafeArea(.keyboard)
+                    .ignoresSafeArea(.container, edges: .bottom)
                     .toolbar(.hidden, for: .navigationBar)
                     .navigationDestination(for: CoinRoute.self) { route in
                         detail(route) { favPath.removeLast() }
@@ -47,11 +51,13 @@ struct LiquidGlassRootView: View {
             Tab("Portfolio", systemImage: "chart.pie.fill", value: 2) {
                 PortfolioComposeView { selection = 3 } // "Open Settings" → Settings tab
                     .ignoresSafeArea(.keyboard)
+                    .ignoresSafeArea(.container, edges: .bottom)
             }
 
             Tab("Settings", systemImage: "gearshape", value: 3) {
                 SettingsComposeView()
                     .ignoresSafeArea(.keyboard)
+                    .ignoresSafeArea(.container, edges: .bottom)
             }
         }
         .tabBarMinimizeBehavior(.onScrollDown)


### PR DESCRIPTION
## Description
On the iOS 26 native Liquid Glass `TabView`, the bottom tab bar looked like an opaque dark pill and screen content did not flow under it. The bar is glass by default, but each tab's Compose view respected the bottom safe area, so the Compose frame ended *above* the bar and the glass frosted the solid `#141313` base layer instead of the list.

This makes all four tabs behave like the iOS Contacts app: content scrolls **under** a transparent glass bar (frosting through it) while the last item still scrolls fully clear so it stays readable.

## Changes Made
- **`iosApp/iosApp/LiquidGlassRootView.swift`** — add `.ignoresSafeArea(.container, edges: .bottom)` to all four tabs (bottom only, so the top status-bar inset is preserved) so Compose draws edge-to-edge under the floating bar.
- **`ui/utils/BottomBarInsets.kt`** (new) — shared `bottomBarClearancePadding(clearance)` helper.
- **`MainViewController.kt`** — `NativeTabBarClearance = 90.dp` passed to the Market/Favorites/Portfolio/Settings iOS-26 `ComposeUIViewController` hosts.
- **`ui/CryptoListScreen.kt`, `ui/PortfolioScreen.kt`, `ui/SettingsScreen.kt`** — new `bottomBarClearance: Dp = 0.dp` param; reserve the bar footprint as list `contentPadding.bottom`. Portfolio and Settings additionally apply only the **top** window inset on the iOS-26 path so the scroll viewport reaches under the bar.
- **`ui/components/ScrollToEdgeButton.kt`** — lift the scroll-to-edge FAB above the bar by the same clearance.
- **`App.kt`** — update the `SettingsScreen` call site to a named argument.

The new param defaults to `0.dp`, set only by the iOS-26 hosts, so the shared `App()` path (Android / Desktop / Web / iOS < 26) renders unchanged.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance improvement

## Testing Done
- [ ] Unit tests added/updated
- [ ] Manual testing on Android
- [x] Manual testing on iOS — iPhone 17 Pro, iOS 26.4 simulator: verified on all four tabs that content frosts under the bar and the last item / FAB clears it; top insets intact.
- [ ] Manual testing on Desktop
- Verified `compileKotlinIosSimulatorArm64` (full iOS app build) and `compileCommonMainKotlinMetadata` both succeed.

## Checklist
- [x] Code follows project style guidelines
- [x] Tests pass locally (no unit tests cover these UI changes; compilation verified)
- [x] No breaking changes (shared/non-iOS26 paths gated to `0.dp` = no-op)

## Known limitation
SwiftUI cannot observe the Compose-hosted scroll view, so the *static* glass frosting works, but the dynamic scroll-edge refraction and `.tabBarMinimizeBehavior(.onScrollDown)` shrink-on-scroll may not engage — a Compose-on-iOS limitation, best-effort only.

## Related Issues
N/A
