### PR TITLE
fix(android): remove black/white strip above the bottom navigation bar

### DIFF
--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -8,10 +8,10 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -234,42 +234,38 @@ fun App(
             bottomBar = {
                 val isCoinDetail = currentDestinationId == CoinDetail.serializer().generateHashCode()
                 if (!isCoinDetail) {
-                    BottomAppBar(
-                        actions = {
-                            val portfolioEnabled = settingsState?.hasPortfolioWallets() == true
-                            val navItems = buildList {
-                                add(NavItem.HomeScreen)
-                                add(NavItem.FavoritesScreen)
-                                if (portfolioEnabled) add(NavItem.PortfolioScreen)
-                                add(NavItem.SettingsScreen)
-                            }
+                    val portfolioEnabled = settingsState?.hasPortfolioWallets() == true
+                    val navItems = buildList {
+                        add(NavItem.HomeScreen)
+                        add(NavItem.FavoritesScreen)
+                        if (portfolioEnabled) add(NavItem.PortfolioScreen)
+                        add(NavItem.SettingsScreen)
+                    }
 
-                            NavigationBar {
-                                navItems.forEach { item ->
-                                    NavigationBarItem(
-                                        alwaysShowLabel = false,
-                                        icon = {
-                                            Icon(
-                                                imageVector = item.icon,
-                                                contentDescription = item.title
-                                            )
-                                        },
-                                        label = { Text(item.title) },
-                                        selected = currentDestinationId == item.destinationId(),
-                                        onClick = {
-                                            navController.navigate(item.path) {
-                                                popUpTo(navController.graph.startDestinationId) {
-                                                    saveState = true
-                                                }
-                                                launchSingleTop = true
-                                                restoreState = true
-                                            }
-                                        }
+                    NavigationBar {
+                        navItems.forEach { item ->
+                            NavigationBarItem(
+                                alwaysShowLabel = false,
+                                icon = {
+                                    Icon(
+                                        imageVector = item.icon,
+                                        contentDescription = item.title
                                     )
+                                },
+                                label = { Text(item.title) },
+                                selected = currentDestinationId == item.destinationId(),
+                                onClick = {
+                                    navController.navigate(item.path) {
+                                        popUpTo(navController.graph.startDestinationId) {
+                                            saveState = true
+                                        }
+                                        launchSingleTop = true
+                                        restoreState = true
+                                    }
                                 }
-                            }
+                            )
                         }
-                    )
+                    }
                 }
             }
         ) { innerPadding ->
@@ -279,6 +275,10 @@ fun App(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
+                    // The root Scaffold reserves the bottom nav-bar / system-bar inset here. Mark it
+                    // consumed so nested per-screen Scaffolds (Portfolio, Settings) don't re-apply the
+                    // same bottom inset and open a surface-colored strip above the bottom bar.
+                    .consumeWindowInsets(innerPadding)
             ) {
                 animatedComposable<Market> {
                     CryptoList(


### PR DESCRIPTION
## Problem

A thin black (dark theme) / white (light theme) strip appeared between the bottom of the scrolling content and the bottom navigation bar — most visible on the **Portfolio** screen, but also latent on **Settings**.

| Before | After |
|---|---|
| ~27dp pure-`surface` band above the nav bar | content flows flush to the bar |

## Root cause

A **double-applied bottom window inset**, not the bar component.

- The root `Scaffold` in `App()` reserves the bottom system-bar / gesture-nav inset and the `NavHost` applies it via `.padding(innerPadding)` — but never **consumes** it.
- So `WindowInsets.systemBars.bottom` stayed "available," and every per-screen **nested** `Scaffold` that also does `.padding(innerPadding)` (Portfolio, Settings) re-applied it a second time. That extra inset exposed a band of `surface` color (pure black / white) above the bar.
- Market/Favorites were immune because their nested `Scaffold` ignores `innerPadding`.
- The symmetric problem at the **top** was already worked around per-screen via `windowInsets = WindowInsets(top = 0.dp, bottom = 0.dp)` on the nested top bars; the bottom was the unfixed half.

## Fix

Pair the existing `.padding(innerPadding)` on the `NavHost` with `.consumeWindowInsets(innerPadding)` — the idiomatic Compose pattern for hosting nested `Scaffold`s. One line at the architectural seam fixes Portfolio **and** Settings.

Also flattens the `bottomBar` from `BottomAppBar(actions = { NavigationBar { … } })` to a bare `NavigationBar` (the wrapper was a redundant second bar surface).

## Verification

- Built + installed on an Android emulator; row-by-row pixel analysis confirms the pure-black band directly above the nav bar (y≈2090–2150) is replaced by card content, while the nav bar itself is pixel-identical.
- Adversarial multi-agent review traced the change against decompiled Material3 1.9.0 / foundation-layout 1.11.1 sources — no regression to the top status-bar inset, the CoinDetail route (bottom bar hidden), the iOS 26 native-TabView path, Desktop/Web, or IME.

## Scope

- Single file: `composeApp/src/commonMain/kotlin/App.kt`
- iOS 26 hosts screens in a native SwiftUI `TabView` (not `App()`'s NavHost), so that path is unaffected; Desktop/Web have no system insets (no-op).