### PR TITLE
[FIX] Restore iOS coin-detail swipe-back and Settings back arrow

### DIFF
--- a/composeApp/src/iosMain/kotlin/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/MainViewController.kt
@@ -78,9 +78,9 @@ fun FavoritesViewController(onCoin: (String, String) -> Unit): UIViewController 
         IosScreen { FavoritesListScreen(IosShared.cryptoViewModel, onCoin, bottomBarClearance = NativeTabBarClearance) }
     }
 
-fun SettingsViewController(): UIViewController =
+fun SettingsViewController(onBack: () -> Unit): UIViewController =
     ComposeUIViewController {
-        IosScreen { SettingsScreen(onBackPress = {}, bottomBarClearance = NativeTabBarClearance) }
+        IosScreen { SettingsScreen(onBackPress = onBack, bottomBarClearance = NativeTabBarClearance) }
     }
 
 /** Portfolio screen for the iOS 26 native-TabView path. [onConfigure] should select Settings. */

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
 		AB10C5EE2E00000000000001 /* ComposeScreens.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB10C5EE2E00000000000002 /* ComposeScreens.swift */; };
 		AB10C5EE2E00000000000003 /* LiquidGlassRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB10C5EE2E00000000000004 /* LiquidGlassRootView.swift */; };
+		AB10C5EE2E00000000000005 /* UINavigationController+Swipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB10C5EE2E00000000000006 /* UINavigationController+Swipe.swift */; };
 		D65EDBB62EF76C8C00267519 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D65EDBB52EF76C8C00267519 /* WidgetKit.framework */; };
 		D65EDBB82EF76C8C00267519 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D65EDBB72EF76C8C00267519 /* SwiftUI.framework */; };
 		D65EDBC92EF76C8D00267519 /* UTXOWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = D65EDBB42EF76C8C00267519 /* UTXOWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -51,6 +52,7 @@
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AB10C5EE2E00000000000002 /* ComposeScreens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeScreens.swift; sourceTree = "<group>"; };
 		AB10C5EE2E00000000000004 /* LiquidGlassRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlassRootView.swift; sourceTree = "<group>"; };
+		AB10C5EE2E00000000000006 /* UINavigationController+Swipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Swipe.swift"; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		D65EDBB42EF76C8C00267519 /* UTXOWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = UTXOWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		D65EDBB52EF76C8C00267519 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
@@ -139,6 +141,7 @@
 				7555FF82242A565900829871 /* ContentView.swift */,
 				AB10C5EE2E00000000000002 /* ComposeScreens.swift */,
 				AB10C5EE2E00000000000004 /* LiquidGlassRootView.swift */,
+				AB10C5EE2E00000000000006 /* UINavigationController+Swipe.swift */,
 				7555FF8C242A565B00829871 /* Info.plist */,
 				2152FB032600AC8F00CF470E /* iOSApp.swift */,
 				058557D7273AAEEB004C7B11 /* Preview Content */,
@@ -290,6 +293,7 @@
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
 				AB10C5EE2E00000000000001 /* ComposeScreens.swift in Sources */,
 				AB10C5EE2E00000000000003 /* LiquidGlassRootView.swift in Sources */,
+				AB10C5EE2E00000000000005 /* UINavigationController+Swipe.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosApp/ComposeScreens.swift
+++ b/iosApp/iosApp/ComposeScreens.swift
@@ -26,8 +26,11 @@ struct FavoritesComposeView: UIViewControllerRepresentable {
 }
 
 struct SettingsComposeView: UIViewControllerRepresentable {
+    /// Invoked by the screen's back arrow; should return to the tab Settings was opened from.
+    let onBack: () -> Void
+
     func makeUIViewController(context: Context) -> UIViewController {
-        MainViewControllerKt.SettingsViewController()
+        MainViewControllerKt.SettingsViewController(onBack: onBack)
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}

--- a/iosApp/iosApp/LiquidGlassRootView.swift
+++ b/iosApp/iosApp/LiquidGlassRootView.swift
@@ -13,6 +13,8 @@ struct CoinRoute: Hashable {
 struct LiquidGlassRootView: View {
     @EnvironmentObject private var urlHandler: URLHandler
     @State private var selection = 0
+    /// Tab that Settings was opened from, so its back arrow can return there (tabs have no back stack).
+    @State private var previousSelection = 0
     @State private var marketPath = NavigationPath()
     @State private var favPath = NavigationPath()
 
@@ -55,7 +57,7 @@ struct LiquidGlassRootView: View {
             }
 
             Tab("Settings", systemImage: "gearshape", value: 3) {
-                SettingsComposeView()
+                SettingsComposeView { selection = previousSelection } // back → origin tab
                     .ignoresSafeArea(.keyboard)
                     .ignoresSafeArea(.container, edges: .bottom)
             }
@@ -65,7 +67,9 @@ struct LiquidGlassRootView: View {
             MainViewControllerKt.cryptoResume()
             consumeDeepLink() // handle a link delivered before observation started
         }
-        .onChange(of: selection) { _, newValue in
+        .onChange(of: selection) { oldValue, newValue in
+            // Remember where Settings was entered from so its back arrow can return there.
+            if newValue == 3 { previousSelection = oldValue }
             // Market(0)/Favorites(1) need the live market stream; Portfolio(2)/Settings(3) don't.
             if newValue == 0 || newValue == 1 {
                 MainViewControllerKt.cryptoResume()

--- a/iosApp/iosApp/UINavigationController+Swipe.swift
+++ b/iosApp/iosApp/UINavigationController+Swipe.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+/// Restores the standard iOS left-edge swipe-to-go-back gesture.
+///
+/// Our coin-detail route lives in a SwiftUI `NavigationStack` whose nav bar is hidden
+/// (`.toolbar(.hidden, for: .navigationBar)` in `LiquidGlassRootView`) because the Compose
+/// screen draws its own top bar. Hiding the nav bar also disables UIKit's
+/// `interactivePopGestureRecognizer` by default — the edge-pop is tied to the visible back
+/// button — so only the in-screen back button worked. Re-pointing the gesture's delegate at the
+/// navigation controller and allowing it whenever there is something to pop brings the native
+/// swipe-back behavior back.
+///
+/// The `viewControllers.count > 1` guard means the gesture only fires on a pushed screen
+/// (coin detail), never on a tab's list root.
+extension UINavigationController: UIGestureRecognizerDelegate {
+    open override func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        viewControllers.count > 1
+    }
+}


### PR DESCRIPTION
## Description
On iOS 26+ the app hosts each tab in a native SwiftUI `TabView` with a per-tab `NavigationStack` (`LiquidGlassRootView.swift`). Two back-navigation affordances were broken on that path:

1. **Coin-detail edge-swipe did nothing.** The detail route hides the nav bar via `.toolbar(.hidden, for: .navigationBar)`, which also disables UIKit's `interactivePopGestureRecognizer` (the edge-pop is tied to the visible back button). Only the in-screen back button worked.
2. **Settings back arrow was a no-op.** `SettingsViewController()` passed `onBackPress = {}` — Settings is a root tab with no back stack, so the arrow did nothing.

## Changes Made
- **`iosApp/iosApp/UINavigationController+Swipe.swift`** (new) — re-points the interactive pop gesture's delegate at the nav controller and allows it when `viewControllers.count > 1`, restoring the native left-edge swipe-back. Guard means it only fires on a pushed screen (coin detail), never on a tab root.
- **`iosApp/iosApp.xcodeproj/project.pbxproj`** — registers the new Swift file (build file, file ref, group, sources phase).
- **`iosApp/iosApp/LiquidGlassRootView.swift`** — tracks `previousSelection` (the tab Settings was opened from) and passes `{ selection = previousSelection }` into the Settings tab.
- **`iosApp/iosApp/ComposeScreens.swift`** — `SettingsComposeView` gains an `onBack` closure.
- **`composeApp/src/iosMain/kotlin/MainViewController.kt`** — `SettingsViewController(onBack:)` forwards the callback to the Compose screen's existing `onBackPress`.

Android and iOS<26 Compose-`NavHost` paths are untouched.

## Type of Change
- [x] Bug fix

## Testing Done
- [x] Manual testing on iOS (iPhone 17 Pro · iOS 26.5 simulator)
- [x] Manual testing on Android (Pixel 10 Pro emulator)
- [ ] Unit tests added/updated (n/a — navigation/gesture behavior)

### iOS 26.5 (full app build via xcodebuild: BUILD SUCCEEDED)
- Coin detail: left-edge swipe pops the NavigationStack (WBTC → ETH → Market list). ✅
- Settings back arrow returns to the origin tab — Market when opened from Market, Portfolio when opened from Portfolio's "Open Settings". ✅

### Android (regression — no code change on this path)
- Coin detail: system back (gesture/key) and back-arrow button → Market list. ✅
- Settings: back-arrow button and system back → Market. ✅

## Checklist
- [x] Code follows project style guidelines
- [x] No breaking changes
- [x] Changes scoped to `iosApp/` and `composeApp/src/iosMain/` only