### PR TITLE
chore(ios): bump version to 0.4.8 (build 48)

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -443,7 +443,7 @@
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 47;
+				CURRENT_PROJECT_VERSION = 48;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = 37UYJHD27F;
 				ENABLE_PREVIEWS = YES;
@@ -459,7 +459,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.7;
+				MARKETING_VERSION = 0.4.8;
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = org.androdevlinux.utxo.UTXO;
 				PRODUCT_NAME = "${APP_NAME}";
@@ -477,7 +477,7 @@
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 47;
+				CURRENT_PROJECT_VERSION = 48;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = 37UYJHD27F;
 				ENABLE_PREVIEWS = YES;
@@ -493,7 +493,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.7;
+				MARKETING_VERSION = 0.4.8;
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = org.androdevlinux.utxo.UTXO;
 				PRODUCT_NAME = "${APP_NAME}";


### PR DESCRIPTION
## Summary

Bumps the iOS Xcode project version to match the v0.4.8 release (#277):

- `MARKETING_VERSION`: `0.4.7` → `0.4.8`
- `CURRENT_PROJECT_VERSION`: `47` → `48`

Applied to both Debug and Release build configurations.

## Why

The v0.4.8 release bump (#277) refreshed the app version but did not include the iOS `project.pbxproj`, leaving the Xcode project a version behind. This brings it in sync so iOS builds report the correct marketing/build numbers.

## Test plan

- [ ] iOS app builds and reports version `0.4.8` (build `48`)
- No functional code changes — version metadata only