### PR TITLE
[FIX] Stabilize Hyperliquid portfolio value & positions, add HIP-3 multi-dex

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -149,6 +149,10 @@ kotlin {
             implementation(libs.coil.network.ktor3)
         }
 
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
+
         desktopMain.dependencies {
             implementation(compose.desktop.currentOs)
             implementation(libs.ktor.client.cio)

--- a/composeApp/src/commonMain/kotlin/model/Portfolio.kt
+++ b/composeApp/src/commonMain/kotlin/model/Portfolio.kt
@@ -112,6 +112,17 @@ data class HlPerpState(
     @SerialName("time") val time: Long = 0,
 )
 
+/**
+ * One builder-deployed (HIP-3) perp dex from the `perpDexs` info response. That response is a JSON
+ * array whose first element is `null` (the main dex) and whose remaining elements are objects; only
+ * [name] is needed — it is passed as the `dex` parameter to query that dex's `clearinghouseState`.
+ * Alt-dex asset coins are namespaced (e.g. "xyz:TSLA"), so positions are self-identifying.
+ */
+@Serializable
+data class HlPerpDex(
+    @SerialName("name") val name: String = "",
+)
+
 // endregion
 
 // region --- Raw API DTOs (spot) ---

--- a/composeApp/src/commonMain/kotlin/network/HyperliquidService.kt
+++ b/composeApp/src/commonMain/kotlin/network/HyperliquidService.kt
@@ -10,9 +10,15 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
 import logging.AppLogger
+import model.HlPerpDex
 import model.HlPerpState
 import model.HlSpotState
 
@@ -39,6 +45,10 @@ class HyperliquidService {
 
     private val rateLimiter = RateLimiter(maxRequests = 10, windowDurationMillis = 1000)
 
+    // Builder-deployed (HIP-3) perp dex names, fetched once and cached — the set changes rarely.
+    private val dexNamesMutex = Mutex()
+    private var cachedDexNames: List<String>? = null
+
     private val client = HttpClient {
         install(HttpTimeout) {
             connectTimeoutMillis = 15_000
@@ -51,12 +61,53 @@ class HyperliquidService {
         client.close()
     }
 
-    suspend fun fetchPerpState(user: String): HlPerpState? =
-        infoPost("clearinghouseState", user)?.let { body ->
+    /** Perp clearinghouse state for [user] on the main dex, or a builder-deployed [dex] when given. */
+    suspend fun fetchPerpState(user: String, dex: String? = null): HlPerpState? =
+        infoPost("clearinghouseState", user, dex)?.let { body ->
             runCatching { json.decodeFromString<HlPerpState>(body) }
                 .onFailure { AppLogger.logger.e(throwable = it) { "Hyperliquid: failed to parse clearinghouseState" } }
                 .getOrNull()
         }
+
+    /**
+     * Builder-deployed (HIP-3) perp dex names, fetched once and cached. The `perpDexs` array starts
+     * with `null` (the main dex) followed by per-dex objects; we keep the non-null names.
+     */
+    suspend fun perpDexNames(): List<String> {
+        cachedDexNames?.let { return it }
+        return dexNamesMutex.withLock {
+            cachedDexNames?.let { return@withLock it }
+            val body = post("""{"type":"perpDexs"}""", label = "perpDexs") ?: return@withLock emptyList()
+            val names = runCatching {
+                json.decodeFromString<List<HlPerpDex?>>(body)
+                    .filterNotNull()
+                    .map { it.name }
+                    .filter { it.isNotEmpty() }
+            }.getOrElse {
+                AppLogger.logger.e(throwable = it) { "Hyperliquid: failed to parse perpDexs" }
+                emptyList()
+            }
+            // Cache only on success so a transient failure is retried on the next call.
+            if (names.isNotEmpty()) cachedDexNames = names
+            names
+        }
+    }
+
+    /**
+     * Perp state on every builder-deployed (HIP-3) alt dex where [user] has equity or a position.
+     * webData2 and the main `clearinghouseState` cover only the main dex, so alt dexes must be
+     * fetched separately. Collateral is isolated per dex, so each returned state's accountValue is
+     * additive with the main dex (no shared pool to double-count). Empty dex accounts are dropped.
+     */
+    suspend fun fetchAltPerpStates(user: String): List<HlPerpState> {
+        val names = perpDexNames()
+        if (names.isEmpty()) return emptyList()
+        return coroutineScope {
+            names.map { dex -> async { fetchPerpState(user, dex) } }.awaitAll()
+        }.filterNotNull().filter {
+            it.assetPositions.isNotEmpty() || (it.marginSummary.accountValue.toDoubleOrNull() ?: 0.0) > 0.0
+        }
+    }
 
     suspend fun fetchSpotState(user: String): HlSpotState? =
         infoPost("spotClearinghouseState", user)?.let { body ->
@@ -85,12 +136,21 @@ class HyperliquidService {
     }
 
     /**
-     * POST {"type":<type>,"user":<user>} to the info endpoint and return the raw body,
+     * POST {"type":<type>,"user":<user>[,"dex":<dex>]} to the info endpoint and return the raw body,
      * or null on failure. The request body is built directly to avoid coupling to
      * ContentNegotiation request serialization.
      */
-    private suspend fun infoPost(type: String, user: String): String? {
-        val requestBody = """{"type":"$type","user":"$user"}"""
+    private suspend fun infoPost(type: String, user: String, dex: String? = null): String? {
+        val requestBody = if (dex.isNullOrEmpty()) {
+            """{"type":"$type","user":"$user"}"""
+        } else {
+            """{"type":"$type","user":"$user","dex":"$dex"}"""
+        }
+        return post(requestBody, label = type)
+    }
+
+    /** POST a raw JSON body to the info endpoint with retry/backoff; null on failure. */
+    private suspend fun post(requestBody: String, label: String): String? {
         for (attempt in 0 until MAX_RETRIES) {
             try {
                 rateLimiter.acquire()
@@ -103,7 +163,7 @@ class HyperliquidService {
                     response.status.value == 429 -> delay(1000L * (attempt + 1))      // rate limited
                     response.status.value in 500..599 -> delay(500L * (attempt + 1))  // server error, back off
                     else -> {
-                        AppLogger.logger.w { "Hyperliquid info ($type) returned ${response.status}" }
+                        AppLogger.logger.w { "Hyperliquid info ($label) returned ${response.status}" }
                         return null
                     }
                 }
@@ -111,7 +171,7 @@ class HyperliquidService {
                 throw e
             } catch (e: Exception) {
                 if (attempt == MAX_RETRIES - 1) {
-                    AppLogger.logger.e(throwable = e) { "Hyperliquid info ($type) request failed" }
+                    AppLogger.logger.e(throwable = e) { "Hyperliquid info ($label) request failed" }
                     return null
                 }
                 delay(500L * (attempt + 1))

--- a/composeApp/src/commonMain/kotlin/network/PortfolioWebSocketService.kt
+++ b/composeApp/src/commonMain/kotlin/network/PortfolioWebSocketService.kt
@@ -29,9 +29,16 @@ import model.HlSpotState
 /**
  * Real-time Hyperliquid portfolio stream for a public wallet address.
  *
- * Connects once to wss://api.hyperliquid.xyz/ws and subscribes to:
- *   - webData3 -> perps clearinghouse state (nested under data.clearinghouseState)
- *   - spotState -> spot balances
+ * Connects once to wss://api.hyperliquid.xyz/ws and subscribes to a single `webData2` channel —
+ * one atomic snapshot carrying BOTH:
+ *   - data.clearinghouseState -> perps clearinghouse state. NOTE: MAIN perp dex only; positions on
+ *     HIP-3 builder-deployed dexes are not included here (nor in the HTTP clearinghouseState call).
+ *   - data.spotState.balances  -> spot balances, already reconciled by Hyperliquid: USDC pledged as
+ *     perp collateral is reported as ~0, so it is NOT double-counted on top of accountValue.
+ *
+ * webData2 is the source of truth for live state; the HTTP snapshot in [HyperliquidService] is only
+ * a bootstrap / offline fallback (see WalletStream in PortfolioViewModel). Using one channel also
+ * avoids two streams racing to overwrite each other.
  *
  * Hyperliquid closes idle connections after 60s, so we send an application-level
  * {"method":"ping"} text frame every [PING_INTERVAL_MS]. This is distinct from the

--- a/composeApp/src/commonMain/kotlin/ui/PortfolioScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/PortfolioScreen.kt
@@ -573,12 +573,14 @@ private fun SpotCard(row: SpotBalanceRow, accent: Color) {
 
 @Composable
 private fun CoinMonogram(coin: String, accent: Color) {
+    // Alt-dex coins are namespaced ("xyz:TSLA"); use the symbol after the prefix for the monogram.
+    val symbol = coin.substringAfterLast(':')
     Box(
         modifier = Modifier.size(40.dp).clip(CircleShape).background(accent.copy(alpha = 0.18f)),
         contentAlignment = Alignment.Center,
     ) {
         Text(
-            text = coin.take(if (coin.length >= 2) 2 else 1).uppercase(),
+            text = symbol.take(if (symbol.length >= 2) 2 else 1).uppercase(),
             style = MaterialTheme.typography.labelMedium,
             fontWeight = FontWeight.Bold,
             color = accent,

--- a/composeApp/src/commonMain/kotlin/ui/PortfolioViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/ui/PortfolioViewModel.kt
@@ -148,8 +148,8 @@ class PortfolioViewModel : ViewModel() {
 
     private fun walletDataFlow(address: String): Flow<WalletData> {
         val s = streams[address] ?: return flowOf(emptyWalletData(address))
-        return combine(s.rawPerp, s.rawSpot, s.snapshotError, s.connectionError) { perp, spot, snapErr, wsErr ->
-            buildWalletData(address, perp, spot, snapErr, isStale = wsErr != null)
+        return combine(s.rawPerp, s.rawSpot, s.rawAltPerp, s.snapshotError, s.connectionError) { perp, spot, altPerp, snapErr, wsErr ->
+            buildWalletData(address, perp, spot, altPerp, snapErr, isStale = wsErr != null)
         }
     }
 
@@ -280,35 +280,91 @@ private class WalletStream(
 
     val rawPerp = MutableStateFlow<HlPerpState?>(null)
     val rawSpot = MutableStateFlow<HlSpotState?>(null)
+
+    /**
+     * Perp state on builder-deployed (HIP-3) alt dexes. HTTP-only: webData2 carries the main dex
+     * only, so these are fetched separately and are never touched by the WS collectors.
+     */
+    val rawAltPerp = MutableStateFlow<List<HlPerpState>>(emptyList())
     val snapshotError = MutableStateFlow(false)
     val connectionError: StateFlow<String?> get() = ws.connectionError
 
     private var snapshotJob: Job? = null
 
+    // Source-of-truth bookkeeping (single-writer: mutated only on Main).
+    // webData2 is authoritative for live state; the HTTP snapshot is bootstrap/offline-only.
+    private var wsDelivered = false
+    private var perpFromWs = false
+    private var spotFromWs = false
+
+    /** Alt-dex states are fetched on first snapshot + explicit refresh only, to bound the fan-out. */
+    private var altFetched = false
+
     init {
         // Feed live WS updates into the raw flows (ignore the null resets a disconnect emits).
-        scope.launch { ws.perpState.collect { if (it != null) rawPerp.value = it } }
-        scope.launch { ws.spotState.collect { if (it != null) rawSpot.value = it } }
+        // A non-null frame means webData2 is delivering, so it owns the state from here on.
+        scope.launch {
+            ws.perpState.collect { if (it != null) { wsDelivered = true; applyPerp(it, fromWs = true) } }
+        }
+        scope.launch {
+            ws.spotState.collect { if (it != null) { wsDelivered = true; applySpot(it, fromWs = true) } }
+        }
     }
 
-    private fun loadSnapshot() {
+    /** True while webData2 is connected and has delivered — it then owns [rawPerp]/[rawSpot]. */
+    private fun wsOwnsState(): Boolean = wsDelivered && ws.connectionError.value == null
+
+    /** Apply a perp frame under source-priority + monotonic-time + partial-frame arbitration. */
+    private fun applyPerp(incoming: HlPerpState, fromWs: Boolean) {
+        if (!shouldApplyPerp(rawPerp.value, perpFromWs, incoming, fromWs)) return
+        rawPerp.value = incoming
+        perpFromWs = fromWs
+    }
+
+    /** Apply a spot frame under source-priority + monotonic-time arbitration. */
+    private fun applySpot(incoming: HlSpotState, fromWs: Boolean) {
+        if (!shouldApplySpot(rawSpot.value, spotFromWs, incoming, fromWs)) return
+        rawSpot.value = incoming
+        spotFromWs = fromWs
+    }
+
+    private fun loadSnapshot(force: Boolean = false) {
+        val includeAlt = force || !altFetched
         snapshotJob?.cancel()
         snapshotJob = scope.launch(Dispatchers.Default) {
             val perp = httpService.fetchPerpState(address)
             val spot = httpService.fetchSpotState(address)
             withContext(Dispatchers.Main) {
-                if (perp == null && spot == null) {
-                    snapshotError.value = true
-                } else {
-                    snapshotError.value = false
-                    perp?.let { rawPerp.value = it }
-                    spot?.let { rawSpot.value = it }
+                // webData2 is the source of truth once live; the HTTP snapshot only bootstraps
+                // before the first live frame. Committing it while WS owns the state is what made
+                // the value flip — the HTTP path counts free spot USDC that accountValue
+                // (cross-collateral) already includes. After WS has delivered, shouldApply* keeps
+                // its reconciled frame even across reconnects (the stale banner signals an outage),
+                // so a mid-session HTTP refresh can't re-introduce the inflated value.
+                if (!wsOwnsState()) {
+                    if (perp == null && spot == null) {
+                        snapshotError.value = true
+                    } else {
+                        snapshotError.value = false
+                        perp?.let { applyPerp(it, fromWs = false) }
+                        spot?.let { applySpot(it, fromWs = false) }
+                    }
+                }
+            }
+            // Alt (HIP-3) dexes are HTTP-only and secondary — webData2 never carries them. Fetch
+            // them AFTER the main snapshot so the per-dex fan-out never delays the main data, and
+            // commit regardless of wsOwnsState (the WS path doesn't own this flow).
+            if (includeAlt) {
+                val alt = httpService.fetchAltPerpStates(address)
+                withContext(Dispatchers.Main) {
+                    altFetched = true
+                    rawAltPerp.value = alt
                 }
             }
         }
     }
 
-    fun refresh() = loadSnapshot()
+    fun refresh() = loadSnapshot(force = true)
 
     fun resume() {
         loadSnapshot()
@@ -316,6 +372,10 @@ private class WalletStream(
     }
 
     fun pause() {
+        // Drop the "delivered" latch so the next resume can bootstrap from HTTP again if the
+        // socket is slow; the last (WS-sourced) values are retained until a fresh frame replaces
+        // them, so HTTP can't re-introduce the inflated value on resume.
+        wsDelivered = false
         ws.disconnect()
     }
 
@@ -326,8 +386,71 @@ private class WalletStream(
     }
 }
 
+// region --- Frame arbitration (pure, unit-tested) ---
+
+/**
+ * A partial/half-formed perp payload: it carries margin/equity but no positions. webData2 can
+ * briefly emit such a frame; accepting it would blank out a real open position. Rejecting it keeps
+ * the last good perp state until a consistent frame arrives.
+ */
+internal fun isPartialPerp(state: HlPerpState): Boolean =
+    state.assetPositions.isEmpty() &&
+        ((state.marginSummary.totalMarginUsed.toDoubleOrNull() ?: 0.0) > 0.0 ||
+            (state.marginSummary.accountValue.toDoubleOrNull() ?: 0.0) > 0.0)
+
+/**
+ * Decide whether [incoming] perp frame should replace [current]. webData2 (WS) is the source of
+ * truth: a WS frame always supersedes an HTTP-sourced one, and an HTTP frame never displaces a WS
+ * one. Within the same source, a strictly-older `time` is dropped (`time == 0` ⇒ unknown ⇒ accept).
+ * Partial frames are always rejected.
+ */
+internal fun shouldApplyPerp(
+    current: HlPerpState?,
+    currentFromWs: Boolean,
+    incoming: HlPerpState,
+    incomingFromWs: Boolean,
+): Boolean {
+    if (isPartialPerp(incoming)) return false
+    if (current == null) return true
+    if (incomingFromWs != currentFromWs) return incomingFromWs // WS wins over HTTP, never the reverse
+    if (incoming.time > 0L && current.time > 0L && incoming.time < current.time) return false
+    return true
+}
+
+/**
+ * Decide whether [incoming] spot frame should replace [current]. Same source-priority + monotonic
+ * rules as [shouldApplyPerp]; spot has no "partial" notion (an empty balance list is legitimate).
+ */
+internal fun shouldApplySpot(
+    current: HlSpotState?,
+    currentFromWs: Boolean,
+    incoming: HlSpotState,
+    incomingFromWs: Boolean,
+): Boolean {
+    if (current == null) return true
+    if (incomingFromWs != currentFromWs) return incomingFromWs
+    if (incoming.time > 0L && current.time > 0L && incoming.time < current.time) return false
+    return true
+}
+
+// endregion
+
 /** Spot coins treated as $1 USD for best-effort valuation (no price feed needed). */
 private val STABLECOINS = setOf("USDC", "USDT", "USDT0", "USDE", "USDH", "USD1", "DAI", "USDB", "FDUSD")
+
+/** Hyperliquid's perp settlement / cross-collateral currency. */
+internal const val PERP_COLLATERAL_COIN = "USDC"
+
+/**
+ * True when a spot balance is perp cross-collateral already represented in perp `accountValue`, so
+ * it must NOT be re-added to the portfolio total (doing so double-counts the equity). In
+ * Hyperliquid's unified model the whole spot USDC balance backs the perp account — verified against
+ * the API: `portfolio` accountValue == perp accountValue == spot USDC `total`, and the free part ==
+ * perp `withdrawable`. Scoped to [PERP_COLLATERAL_COIN] only, and only when a perp account exists
+ * (`accountValue > 0`); a pure-spot wallet's USDC is a genuine holding and is counted.
+ */
+internal fun isPerpCollateral(coin: String, accountValue: Double): Boolean =
+    accountValue > 0.0 && coin.uppercase() == PERP_COLLATERAL_COIN
 
 private fun emptyWalletData(address: String): WalletData =
     WalletData(
@@ -341,29 +464,46 @@ private fun emptyWalletData(address: String): WalletData =
         isStale = false,
     )
 
-private fun buildWalletData(
+internal fun buildWalletData(
     address: String,
     perp: HlPerpState?,
     spot: HlSpotState?,
+    altPerps: List<HlPerpState>,
     snapErr: Boolean,
     isStale: Boolean,
 ): WalletData {
-    val positions = perp?.assetPositions
-        ?.map { it.position }
-        ?.filter { it.coin.isNotBlank() && (it.szi.toDoubleOrNull() ?: 0.0) != 0.0 }
-        ?.map { it.toRow() }
-        ?.sortedByDescending { it.notionalUsd }
-        .orEmpty()
+    // Positions across the main dex AND every builder-deployed (HIP-3) alt dex. Alt-dex coins are
+    // namespaced (e.g. "xyz:TSLA"), so they are self-identifying and never collide with main coins.
+    val perpStates = listOfNotNull(perp) + altPerps
+    val positions = perpStates
+        .flatMap { it.assetPositions }
+        .map { it.position }
+        .filter { it.coin.isNotBlank() && (it.szi.toDoubleOrNull() ?: 0.0) != 0.0 }
+        .map { it.toRow() }
+        .sortedByDescending { it.notionalUsd }
+
+    // Collateral is isolated per dex, so per-dex accountValue/margin are additive across dexes (no
+    // shared pool to double-count). The spot-USDC netting is gated on the MAIN account only, since
+    // spot USDC backs the main dex (alt-dex collateral is transferred into each alt dex separately).
+    val mainAccountValue = perp?.marginSummary?.accountValue?.toDoubleOrNull() ?: 0.0
+    val accountValue = perpStates.sumOf { it.marginSummary.accountValue.toDoubleOrNull() ?: 0.0 }
+    val totalMarginUsed = perpStates.sumOf { it.marginSummary.totalMarginUsed.toDoubleOrNull() ?: 0.0 }
+    val withdrawable = perpStates.sumOf { it.withdrawable.toDoubleOrNull() ?: 0.0 }
 
     val balances = spot?.balances
         ?.map { it.toRow() }
-        // Drop fully on-hold stablecoins: that USDC is perp collateral already counted in
-        // accountValue (webData2 reports it as 0; the HTTP spot endpoint returns it on-hold).
+        // USDC is perp cross-collateral: when a perp account exists, the ENTIRE spot USDC balance is
+        // the same money already in accountValue (its free part == perp `withdrawable`), so it is
+        // neither a separate spot holding nor an addition to the total — it would double-count the
+        // equity. It stays visible in the summary as Account / Margin Used / Free. The HTTP snapshot
+        // reports this USDC in full while webData2 reports it as ~0; excluding it here makes both
+        // sources agree on the correct total. Genuine holdings (non-USDC, or USDC on a pure-spot
+        // wallet) are kept.
+        ?.filterNot { isPerpCollateral(it.coin, mainAccountValue) }
         ?.filter { it.total > 0.0 && it.usdValue != 0.0 }
         ?.sortedByDescending { it.usdValue ?: 0.0 }
         .orEmpty()
 
-    val accountValue = perp?.marginSummary?.accountValue?.toDoubleOrNull() ?: 0.0
     val totalPnl = positions.sumOf { it.unrealizedPnl }
     val spotUsd = balances.sumOf { it.usdValue ?: 0.0 }
     val costBasis = accountValue - totalPnl
@@ -371,8 +511,8 @@ private fun buildWalletData(
         totalValue = accountValue + spotUsd,
         accountValue = accountValue,
         totalUnrealizedPnl = totalPnl,
-        totalMarginUsed = perp?.marginSummary?.totalMarginUsed?.toDoubleOrNull() ?: 0.0,
-        withdrawable = perp?.withdrawable?.toDoubleOrNull() ?: 0.0,
+        totalMarginUsed = totalMarginUsed,
+        withdrawable = withdrawable,
         pnlPercent = if (costBasis > 0.0) totalPnl / costBasis * 100.0 else null,
     )
     return WalletData(
@@ -381,7 +521,7 @@ private fun buildWalletData(
         perps = positions,
         spot = balances,
         costBasis = costBasis,
-        hasData = perp != null || spot != null,
+        hasData = perp != null || spot != null || altPerps.isNotEmpty(),
         snapshotError = snapErr,
         isStale = isStale,
     )
@@ -426,8 +566,9 @@ private fun HlSpotBalance.toRow(): SpotBalanceRow {
         total = totalValue,
         available = availableValue,
         hold = holdValue,
-        // Value stablecoins by their AVAILABLE (free) balance — on-hold USDC is perp collateral
-        // already reflected in accountValue, so counting total double-counts it.
+        // Value stablecoins by their AVAILABLE (free) balance. Collateral USDC is excluded entirely
+        // upstream in buildWalletData (it is perp equity, not a spot holding), so this AVAILABLE
+        // basis only applies to genuine spot stablecoins (non-USDC, or USDC on a pure-spot wallet).
         usdValue = if (coin.uppercase() in STABLECOINS) availableValue else null,
     )
 }

--- a/composeApp/src/commonTest/kotlin/ui/PortfolioArbitrationTest.kt
+++ b/composeApp/src/commonTest/kotlin/ui/PortfolioArbitrationTest.kt
@@ -1,0 +1,129 @@
+package ui
+
+import model.HlAssetPosition
+import model.HlMarginSummary
+import model.HlPerpPosition
+import model.HlPerpState
+import model.HlSpotBalance
+import model.HlSpotState
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the frame-arbitration helpers that fix the "two values / blinking positions" bug:
+ * webData2 (WS) is the source of truth, HTTP only bootstraps, older/partial frames are rejected.
+ */
+class PortfolioArbitrationTest {
+
+    private val btcPosition = HlAssetPosition(
+        type = "oneWay",
+        position = HlPerpPosition(coin = "BTC", szi = "-0.04339"),
+    )
+
+    private fun perp(
+        time: Long,
+        accountValue: String = "0",
+        marginUsed: String = "0",
+        positions: List<HlAssetPosition> = emptyList(),
+    ) = HlPerpState(
+        marginSummary = HlMarginSummary(accountValue = accountValue, totalMarginUsed = marginUsed),
+        withdrawable = "0",
+        assetPositions = positions,
+        time = time,
+    )
+
+    private fun spot(time: Long, balances: List<HlSpotBalance> = emptyList()) =
+        HlSpotState(balances = balances, time = time)
+
+    // --- isPartialPerp ---
+
+    @Test
+    fun partial_when_no_positions_but_margin_used() {
+        assertTrue(isPartialPerp(perp(time = 1, marginUsed = "520.69")))
+        assertTrue(isPartialPerp(perp(time = 1, accountValue = "529.27")))
+    }
+
+    @Test
+    fun not_partial_when_truly_empty_account() {
+        // A genuinely empty/flat account (no positions, no margin, no equity) is legitimate.
+        assertFalse(isPartialPerp(perp(time = 1)))
+    }
+
+    @Test
+    fun not_partial_when_positions_present() {
+        assertFalse(isPartialPerp(perp(time = 1, accountValue = "529.27", positions = listOf(btcPosition))))
+    }
+
+    // --- shouldApplyPerp: source priority ---
+
+    @Test
+    fun first_perp_frame_is_always_applied() {
+        assertTrue(shouldApplyPerp(current = null, currentFromWs = false, incoming = perp(1, positions = listOf(btcPosition)), incomingFromWs = true))
+    }
+
+    @Test
+    fun ws_perp_supersedes_http_even_with_older_time() {
+        val httpHeld = perp(time = 1000, accountValue = "538", positions = listOf(btcPosition))
+        val wsFrame = perp(time = 1, accountValue = "529", positions = listOf(btcPosition))
+        assertTrue(shouldApplyPerp(current = httpHeld, currentFromWs = false, incoming = wsFrame, incomingFromWs = true))
+    }
+
+    @Test
+    fun http_perp_never_displaces_ws() {
+        val wsHeld = perp(time = 1, accountValue = "529", positions = listOf(btcPosition))
+        val httpFrame = perp(time = 1000, accountValue = "538", positions = listOf(btcPosition))
+        assertFalse(shouldApplyPerp(current = wsHeld, currentFromWs = true, incoming = httpFrame, incomingFromWs = false))
+    }
+
+    // --- shouldApplyPerp: monotonic time within a source ---
+
+    @Test
+    fun older_same_source_perp_is_rejected() {
+        val held = perp(time = 100, positions = listOf(btcPosition))
+        val older = perp(time = 50, positions = listOf(btcPosition))
+        assertFalse(shouldApplyPerp(current = held, currentFromWs = true, incoming = older, incomingFromWs = true))
+    }
+
+    @Test
+    fun newer_same_source_perp_is_applied() {
+        val held = perp(time = 50, positions = listOf(btcPosition))
+        val newer = perp(time = 100, positions = listOf(btcPosition))
+        assertTrue(shouldApplyPerp(current = held, currentFromWs = true, incoming = newer, incomingFromWs = true))
+    }
+
+    @Test
+    fun unknown_time_zero_perp_is_applied() {
+        // webData2 may omit `time` (=> 0). Don't let an unknown timestamp block a live frame.
+        val held = perp(time = 100, positions = listOf(btcPosition))
+        val unknown = perp(time = 0, positions = listOf(btcPosition))
+        assertTrue(shouldApplyPerp(current = held, currentFromWs = true, incoming = unknown, incomingFromWs = true))
+    }
+
+    // --- shouldApplyPerp: partial guard wins ---
+
+    @Test
+    fun partial_perp_is_rejected_even_as_first_ws_frame() {
+        assertFalse(shouldApplyPerp(current = null, currentFromWs = false, incoming = perp(1, accountValue = "529"), incomingFromWs = true))
+    }
+
+    // --- shouldApplySpot ---
+
+    @Test
+    fun first_spot_frame_is_always_applied() {
+        assertTrue(shouldApplySpot(current = null, currentFromWs = false, incoming = spot(1), incomingFromWs = true))
+    }
+
+    @Test
+    fun ws_spot_supersedes_http_and_http_never_displaces_ws() {
+        val httpHeld = spot(time = 1000, balances = listOf(HlSpotBalance(coin = "USDC", total = "8.78")))
+        val wsFrame = spot(time = 1)
+        assertTrue(shouldApplySpot(current = httpHeld, currentFromWs = false, incoming = wsFrame, incomingFromWs = true))
+        assertFalse(shouldApplySpot(current = wsFrame, currentFromWs = true, incoming = httpHeld, incomingFromWs = false))
+    }
+
+    @Test
+    fun older_same_source_spot_is_rejected() {
+        assertFalse(shouldApplySpot(current = spot(100), currentFromWs = true, incoming = spot(50), incomingFromWs = true))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/ui/PortfolioMultiDexTest.kt
+++ b/composeApp/src/commonTest/kotlin/ui/PortfolioMultiDexTest.kt
@@ -1,0 +1,126 @@
+package ui
+
+import model.HlAssetPosition
+import model.HlMarginSummary
+import model.HlPerpPosition
+import model.HlPerpState
+import model.HlSpotBalance
+import model.HlSpotState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for multi-dex (HIP-3) aggregation in [buildWalletData]: positions on builder-deployed
+ * alt dexes are unioned with the main dex, and per-dex collateral (isolated) is summed without
+ * double-counting. Live API facts verified by curl: `perpDexs` lists alt dexes (xyz, flx, …); a
+ * per-dex `clearinghouseState` has its own accountValue (deployer: 10.0 on main, 9.99 on xyz);
+ * alt-dex asset coins are namespaced ("xyz:TSLA").
+ */
+class PortfolioMultiDexTest {
+
+    private val eps = 1e-6
+
+    private fun perpState(
+        accountValue: String,
+        marginUsed: String = "0",
+        withdrawable: String = "0",
+        positions: List<HlAssetPosition> = emptyList(),
+    ) = HlPerpState(
+        marginSummary = HlMarginSummary(accountValue = accountValue, totalMarginUsed = marginUsed),
+        withdrawable = withdrawable,
+        assetPositions = positions,
+        time = 1L,
+    )
+
+    private fun position(coin: String, szi: String, positionValue: String, pnl: String = "0") =
+        HlAssetPosition(
+            type = "oneWay",
+            position = HlPerpPosition(coin = coin, szi = szi, positionValue = positionValue, unrealizedPnl = pnl),
+        )
+
+    private fun spotState(vararg balances: HlSpotBalance) = HlSpotState(balances = balances.toList(), time = 1L)
+
+    @Test
+    fun alt_dex_positions_are_unioned_and_collateral_is_summed() {
+        val data = buildWalletData(
+            address = "0xmulti",
+            perp = perpState(
+                accountValue = "500.0",
+                marginUsed = "100.0",
+                withdrawable = "400.0",
+                positions = listOf(position("BTC", "-0.04", "2600.0", pnl = "10.0")),
+            ),
+            spot = spotState(HlSpotBalance(coin = "USDC", token = 0, total = "500.0", hold = "100.0")),
+            altPerps = listOf(
+                perpState(
+                    accountValue = "100.0",
+                    marginUsed = "20.0",
+                    withdrawable = "80.0",
+                    positions = listOf(position("xyz:TSLA", "10", "5000.0", pnl = "5.0")),
+                ),
+            ),
+            snapErr = false,
+            isStale = false,
+        )
+
+        // accountValue/margin/withdrawable are summed across the main + alt dex.
+        assertEquals(600.0, data.summary.accountValue, eps)
+        assertEquals(120.0, data.summary.totalMarginUsed, eps)
+        assertEquals(480.0, data.summary.withdrawable, eps)
+        // Collateral USDC excluded (main account exists) -> total == summed equity, no double-count.
+        assertEquals(600.0, data.summary.totalValue, eps)
+        assertEquals(15.0, data.summary.totalUnrealizedPnl, eps) // 10 (BTC) + 5 (xyz:TSLA)
+        // Both positions present; the larger alt-dex notional sorts first.
+        assertEquals(2, data.perps.size)
+        assertEquals("xyz:TSLA", data.perps.first().coin)
+        assertTrue(data.perps.any { it.coin == "BTC" })
+    }
+
+    @Test
+    fun alt_dex_equity_without_positions_still_counts() {
+        // The xyz feeRecipient case: large equity parked on an alt dex with no open position.
+        val data = buildWalletData(
+            address = "0xparked",
+            perp = perpState(accountValue = "500.0", positions = listOf(position("BTC", "-0.04", "2600.0"))),
+            spot = spotState(HlSpotBalance(coin = "USDC", token = 0, total = "500.0", hold = "0.0")),
+            altPerps = listOf(perpState(accountValue = "200.0")), // collateral, no positions
+            snapErr = false,
+            isStale = false,
+        )
+        assertEquals(700.0, data.summary.accountValue, eps)
+        assertEquals(700.0, data.summary.totalValue, eps)
+        assertEquals(1, data.perps.size) // only the main-dex BTC position
+    }
+
+    @Test
+    fun no_alt_dexes_matches_main_only_behavior() {
+        val data = buildWalletData(
+            address = "0xmain",
+            perp = perpState(accountValue = "535.78125", marginUsed = "519.395656", withdrawable = "16.385594"),
+            spot = spotState(HlSpotBalance(coin = "USDC", token = 0, total = "535.78125052", hold = "519.395656")),
+            altPerps = emptyList(),
+            snapErr = false,
+            isStale = false,
+        )
+        assertEquals(535.78125, data.summary.totalValue, eps)
+        assertEquals(535.78125, data.summary.accountValue, eps)
+    }
+
+    @Test
+    fun alt_dex_only_wallet_has_data() {
+        // No main perp/spot, only an alt-dex account — must still surface as data, not empty.
+        val data = buildWalletData(
+            address = "0xaltonly",
+            perp = null,
+            spot = null,
+            altPerps = listOf(perpState(accountValue = "100.0", positions = listOf(position("flx:GOLD", "1", "1000.0")))),
+            snapErr = false,
+            isStale = false,
+        )
+        assertTrue(data.hasData)
+        assertEquals(100.0, data.summary.accountValue, eps)
+        assertEquals(1, data.perps.size)
+        assertEquals("flx:GOLD", data.perps.first().coin)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/ui/PortfolioValuationTest.kt
+++ b/composeApp/src/commonTest/kotlin/ui/PortfolioValuationTest.kt
@@ -1,0 +1,144 @@
+package ui
+
+import model.HlAssetPosition
+import model.HlMarginSummary
+import model.HlPerpPosition
+import model.HlPerpState
+import model.HlSpotBalance
+import model.HlSpotState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the spot-USDC cross-collateral netting in [buildWalletData].
+ *
+ * Ground truth from the live Hyperliquid API for 0x5277d597151bad688f442949ff4bf7e06075ebfb:
+ *   portfolio.accountValue == perp accountValue == spot USDC total == 535.78125,
+ *   spot USDC hold == perp totalMarginUsed == 519.395656,
+ *   spot USDC available == perp withdrawable == 16.385594.
+ * The whole spot USDC is the perp equity, so the correct Portfolio Value is 535.78 — NOT
+ * 535.78 + 16.39 = 552.17 (the old double-count).
+ */
+class PortfolioValuationTest {
+
+    private val eps = 1e-6
+
+    private fun perpState(
+        accountValue: String,
+        marginUsed: String = "0",
+        withdrawable: String = "0",
+        positions: List<HlAssetPosition> = emptyList(),
+    ) = HlPerpState(
+        marginSummary = HlMarginSummary(accountValue = accountValue, totalMarginUsed = marginUsed),
+        withdrawable = withdrawable,
+        assetPositions = positions,
+        time = 1L,
+    )
+
+    private fun spotState(vararg balances: HlSpotBalance) = HlSpotState(balances = balances.toList(), time = 1L)
+
+    private fun bal(coin: String, total: String, hold: String = "0", token: Int = 0) =
+        HlSpotBalance(coin = coin, token = token, total = total, hold = hold)
+
+    private val btcShort = HlAssetPosition(
+        type = "oneWay",
+        position = HlPerpPosition(
+            coin = "BTC",
+            szi = "-0.04339",
+            entryPx = "60188.0",
+            positionValue = "2596.97828",
+            unrealizedPnl = "14.57904",
+            marginUsed = "519.395656",
+        ),
+    )
+
+    // --- isPerpCollateral ---
+
+    @Test
+    fun usdc_is_collateral_only_when_a_perp_account_exists() {
+        assertTrue(isPerpCollateral("USDC", 535.78125))
+        assertTrue(isPerpCollateral("usdc", 535.78125)) // case-insensitive
+        assertFalse(isPerpCollateral("USDC", 0.0)) // pure-spot wallet
+        assertFalse(isPerpCollateral("USDT", 535.78125)) // only the settlement currency
+    }
+
+    // --- buildWalletData: the real bug ---
+
+    @Test
+    fun unified_account_excludes_collateral_usdc_from_total() {
+        val data = buildWalletData(
+            address = "0x5277",
+            perp = perpState(
+                accountValue = "535.78125",
+                marginUsed = "519.395656",
+                withdrawable = "16.385594",
+                positions = listOf(btcShort),
+            ),
+            spot = spotState(
+                bal(coin = "USDC", total = "535.78125052", hold = "519.395656"),
+                bal(coin = "USDE", total = "0.0", token = 235),
+            ),
+            altPerps = emptyList(),
+            snapErr = false,
+            isStale = false,
+        )
+        // Correct equity — the free USDC (16.39 == withdrawable) is NOT added on top.
+        assertEquals(535.78125, data.summary.totalValue, eps)
+        assertEquals(data.summary.accountValue, data.summary.totalValue, eps)
+        assertEquals(16.385594, data.summary.withdrawable, eps)
+        // Collateral USDC is not shown as a spot holding; the BTC short still renders.
+        assertTrue(data.spot.none { it.coin == "USDC" })
+        assertEquals(1, data.perps.size)
+        assertEquals("BTC", data.perps.first().coin)
+    }
+
+    @Test
+    fun old_double_counted_value_is_not_produced() {
+        val data = buildWalletData(
+            address = "0x5277",
+            perp = perpState(accountValue = "535.78125", marginUsed = "519.395656", withdrawable = "16.385594"),
+            spot = spotState(bal(coin = "USDC", total = "535.78125052", hold = "519.395656")),
+            altPerps = emptyList(),
+            snapErr = false,
+            isStale = false,
+        )
+        assertFalse(data.summary.totalValue > 552.0) // would be 552.17 with the old `+ available` bug
+    }
+
+    // --- buildWalletData: cases that must still count spot value ---
+
+    @Test
+    fun pure_spot_wallet_counts_its_usdc() {
+        val data = buildWalletData(
+            address = "0xspot",
+            perp = null, // no perp account
+            spot = spotState(bal(coin = "USDC", total = "100.0", hold = "0.0")),
+            altPerps = emptyList(),
+            snapErr = false,
+            isStale = false,
+        )
+        assertEquals(0.0, data.summary.accountValue, eps)
+        assertEquals(100.0, data.summary.totalValue, eps)
+        assertTrue(data.spot.any { it.coin == "USDC" })
+    }
+
+    @Test
+    fun non_usdc_spot_stablecoin_is_still_counted_alongside_perp() {
+        val data = buildWalletData(
+            address = "0xmix",
+            perp = perpState(accountValue = "500.0", marginUsed = "0.0", withdrawable = "500.0"),
+            spot = spotState(
+                bal(coin = "USDC", total = "500.0", hold = "0.0"), // collateral -> excluded
+                bal(coin = "USDT", total = "50.0", hold = "0.0", token = 268), // genuine holding -> counted
+            ),
+            altPerps = emptyList(),
+            snapErr = false,
+            isStale = false,
+        )
+        assertEquals(550.0, data.summary.totalValue, eps)
+        assertTrue(data.spot.none { it.coin == "USDC" })
+        assertTrue(data.spot.any { it.coin == "USDT" })
+    }
+}


### PR DESCRIPTION
## Description
The Portfolio screen showed **two different values for the same Hyperliquid account** and could intermittently list **no open positions**. Root cause: each wallet's HTTP snapshot and the live `webData2` WebSocket frame wrote the same `rawPerp`/`rawSpot` flows last-writer-wins, and the spot USDC (perp cross-collateral) was added on top of `accountValue` — the same money, double-counted.

Verified against the live Hyperliquid API for `0x5277…ebfb`: it is one account, ~$535 equity, one BTC short. The `portfolio` endpoint's accountValue equals both the perp accountValue and the spot USDC total, confirming the unified cross-collateral pool.

## Changes Made
- **`ui/PortfolioViewModel.kt`** — `webData2` is now the single source of truth for live state; the HTTP snapshot is bootstrap/offline-only via a `wsOwnsState()` gate plus pure source-priority arbitration (`shouldApplyPerp`/`shouldApplySpot`/`isPartialPerp`). Older and partial perp frames are rejected so a half-formed/stale frame can't blank an open position.
- **`ui/PortfolioViewModel.kt`** — `isPerpCollateral` excludes USDC cross-collateral from the total/spot list when a perp account exists (`accountValue > 0`); pure-spot wallets and non-USDC stablecoins still count.
- **HIP-3 multi-dex support** — `network/HyperliquidService.kt` discovers builder-deployed dexes via `perpDexs` (cached) and fetches per-dex `clearinghouseState` (new `dex` param) in parallel; `buildWalletData` unions positions across dexes and sums isolated per-dex collateral. Alt-dex coins are namespaced (`xyz:TSLA`). Fetched after the main snapshot and bounded to first-load + pull-to-refresh.
- **`network/PortfolioWebSocketService.kt`** — fixed the stale `webData3` KDoc (code subscribes `webData2`, main-dex only).
- **`ui/PortfolioScreen.kt`** — `CoinMonogram` strips the dex prefix for namespaced coins.
- **`model/Portfolio.kt`** — added `HlPerpDex` model for the `perpDexs` response.
- **`build.gradle.kts`** — added a `commonTest` source set (`kotlin("test")`); the project previously had no tests.

## Type of Change
- [x] Bug fix (two values / blinking positions / USDC double-count)
- [x] New feature (HIP-3 multi-dex positions)
- [x] Refactoring (extracted `post()`; pure arbitration helpers)

## Testing Done
- [x] Unit tests added — 22 tests across `PortfolioArbitrationTest`, `PortfolioValuationTest`, `PortfolioMultiDexTest`
- [x] `./gradlew :composeApp:desktopTest` → 22/22 pass
- [x] Validated all dollar figures against the live Hyperliquid `info` API (`clearinghouseState`, `spotClearinghouseState`, `portfolio`, `perpDexs`)
- [ ] On-device manual verification (iOS) — recommended before merge

## Known limitations (documented in code)
- Alt-dex positions are **not live** — they refresh on first view and pull-to-refresh only (`webData2` carries the main dex only; live alt-dex would need `webData3`).
- The alt-dex fan-out is one parallel call per builder dex (currently 9), throttled by the shared rate limiter and issued after the main snapshot.

## Checklist
- [x] Code follows project style guidelines
- [x] Tests pass locally
- [x] No breaking changes
