### PR TITLE
[FIX] Persist iOS settings in Application Support to stop favorites/portfolio loss

### DIFF
--- a/composeApp/src/iosMain/kotlin/App.ios.kt
+++ b/composeApp/src/iosMain/kotlin/App.ios.kt
@@ -18,7 +18,9 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.io.files.Path
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
+import platform.Foundation.NSApplicationSupportDirectory
 import platform.Foundation.NSCachesDirectory
+import platform.Foundation.NSFileManager
 import platform.Foundation.NSSearchPathForDirectoriesInDomains
 import platform.Foundation.NSURL
 import platform.Foundation.NSUserDomainMask
@@ -81,12 +83,45 @@ actual class NetworkConnectivityObserver {
     }
 }
 
+@OptIn(ExperimentalForeignApi::class)
 actual fun getKStore(): KStore<Settings> {
-    val paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, true)
-    return storeOf<Settings>(
-        file = Path("${paths.firstOrNull() as? String}/settings.json"),
-        default = Settings()
-    )
+    val fileManager = NSFileManager.defaultManager
+
+    val appSupportDir = NSSearchPathForDirectoriesInDomains(
+        NSApplicationSupportDirectory, NSUserDomainMask, true
+    ).firstOrNull() as? String
+
+    val cachesDir = NSSearchPathForDirectoriesInDomains(
+        NSCachesDirectory, NSUserDomainMask, true
+    ).firstOrNull() as? String
+
+    // Fall back to Caches only if Application Support can't be resolved (should not happen on iOS).
+    val baseDir = appSupportDir ?: cachesDir
+        ?: return storeOf(file = Path("settings.json"), default = Settings())
+
+    // Application Support often doesn't exist yet on iOS; create it. Best-effort.
+    if (appSupportDir != null && !fileManager.fileExistsAtPath(appSupportDir)) {
+        fileManager.createDirectoryAtPath(
+            path = appSupportDir,
+            withIntermediateDirectories = true,
+            attributes = null,
+            error = null
+        )
+    }
+
+    val newPath = "$baseDir/settings.json"
+
+    // One-time, idempotent, best-effort migration from the old (purgeable) Caches location.
+    if (appSupportDir != null && cachesDir != null) {
+        val oldPath = "$cachesDir/settings.json"
+        if (!fileManager.fileExistsAtPath(newPath) && fileManager.fileExistsAtPath(oldPath)) {
+            runCatching {
+                fileManager.copyItemAtPath(oldPath, toPath = newPath, error = null)
+            }
+        }
+    }
+
+    return storeOf(file = Path(newPath), default = Settings())
 }
 
 // Singleton WebSocket client to prevent memory leaks from multiple instances


### PR DESCRIPTION
## Description

On iOS — and worst of all when the iOS app runs on macOS (Apple Silicon, "Designed for iPad") — favorites and portfolio/wallet data were wiped on every new launch.

**Root cause:** All persistent user state (favorites `favPairs`, Hyperliquid wallets, portfolio scope, theme, RSS providers) is serialized by KStore into a single `settings.json`. On iOS that file was written to `NSCachesDirectory`, which Apple designates as purgeable — the system reclaims it under disk pressure, on app update, and far more aggressively under the macOS runtime. When the file disappears, KStore silently falls back to `Settings()` defaults, so all user data appears erased.

**Fix:** Move iOS storage to `NSApplicationSupportDirectory` (Apple's standard persistent, app-managed, non-purgeable location), with a one-time migration from the old Caches path so existing users keep their data when they update.

## Changes Made
- `composeApp/src/iosMain/kotlin/App.ios.kt` — rewrote `getKStore()`:
  - Resolves `NSApplicationSupportDirectory` (falls back to Caches only if it can't be resolved, which shouldn't happen on iOS).
  - Creates the Application Support directory if missing — KStore / kotlinx-io do not create parent dirs (same reason the Desktop actual already calls `mkdirs()`).
  - One-time, idempotent, best-effort migration: if the new file doesn't exist but the old `Caches/settings.json` does, copy it forward (`runCatching`, old file left in place as a downgrade fallback).
  - Added `@OptIn(ExperimentalForeignApi::class)` (required by the new `NSFileManager` `NSError**` out-params) and imports for `NSApplicationSupportDirectory` / `NSFileManager`.
- No new dependencies.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance improvement

## Testing Done
- [ ] Unit tests added/updated
- [ ] Manual testing on Android
- [x] Manual testing on iOS (if applicable) — pending device/Mac verification (see below)
- [ ] Manual testing on Desktop (if applicable)

`./gradlew :composeApp:compileKotlinIosSimulatorArm64` → BUILD SUCCESSFUL (verifies the new cinterop compiles; no new warnings from the change).

Manual verification still to run on hardware:
1. Existing-user migration: add favorites + a wallet on the current build, install this build over it, confirm data survives first launch.
2. macOS persistence (the reported bug): add data on an Apple Silicon Mac, fully quit, relaunch — data must persist across repeated launches.
3. Fresh install: no crash, empty state, then data persists after relaunch.

## Checklist
- [x] Code follows project style guidelines
- [x] Tests pass locally (iOS target compiles; project has no `ktlintCheck` task and iosMain has no unit tests)
- [x] No breaking changes

## Notes / Follow-up (out of scope, intentionally deferred)
- **Android has the same latent bug:** `getKStore()` uses `context.cacheDir` (`App.android.kt`). A "Clear cache" or storage-pressure event will wipe Android users' data identically. Recommend a follow-up to move to `context.filesDir` with a `cacheDir → filesDir` migration.
- `Settings.favPairs` default is `listOf("")` (phantom empty favorite) — should become `emptyList()`.
- Dead, never-called `iosApp/iosApp/SettingsSyncHelper.swift`.

## Related Issues
N/A