### PR TITLE
[CHORE] Bump Android compileSdk and targetSdk to 37

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 agp = "9.2.1"
-android-compileSdk = "36"
+android-compileSdk = "37"
 android-minSdk = "24"
-android-targetSdk = "36"
+android-targetSdk = "37"
 androidx-activityCompose = "1.13.0"
 atomicfu = "0.33.0"
 kotlin = "2.4.0"


### PR DESCRIPTION
## Description
Bumps the Android build configuration to SDK level 37 for both compile and target SDK versions.

## Changes Made
- `gradle/libs.versions.toml`: `android-compileSdk` 36 → 37
- `gradle/libs.versions.toml`: `android-targetSdk` 36 → 37

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [x] Chore / build configuration

## Testing Done
- [ ] Unit tests added/updated
- [x] CI build (Android) validates the SDK bump
- [ ] Manual testing on iOS (N/A — Android build config only)
- [ ] Manual testing on Desktop (N/A)

## Checklist
- [x] Code follows project style guidelines
- [x] No breaking changes

## Related Issues
N/A