### PR TITLE
[CHORE] Bump version to 0.4.9

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -443,7 +443,7 @@
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 48;
+				CURRENT_PROJECT_VERSION = 49;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = 37UYJHD27F;
 				ENABLE_PREVIEWS = YES;
@@ -459,7 +459,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.8;
+				MARKETING_VERSION = 0.4.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = org.androdevlinux.utxo.UTXO;
 				PRODUCT_NAME = "${APP_NAME}";
@@ -477,7 +477,7 @@
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 48;
+				CURRENT_PROJECT_VERSION = 49;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = 37UYJHD27F;
 				ENABLE_PREVIEWS = YES;
@@ -493,7 +493,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.8;
+				MARKETING_VERSION = 0.4.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = org.androdevlinux.utxo.UTXO;
 				PRODUCT_NAME = "${APP_NAME}";

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-versionName=0.4.8
-versionCode=408
+versionName=0.4.9
+versionCode=409


### PR DESCRIPTION
## Description
Version bump to **0.4.9** across iOS and Android ahead of the next release. No functional code changes.

## Changes Made
- **iOS** (`iosApp/iosApp.xcodeproj/project.pbxproj`): `MARKETING_VERSION` 0.4.8 → 0.4.9, `CURRENT_PROJECT_VERSION` 48 → 49 (both build configs)
- **Android** (`version.properties`): `versionName` 0.4.8 → 0.4.9, `versionCode` 408 → 409

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance improvement
- [x] Chore (release/version bump)

## Testing Done
- [ ] Unit tests added/updated
- [ ] Manual testing on Android
- [ ] Manual testing on iOS (if applicable)
- [ ] Manual testing on Desktop (if applicable)

Version-only change; no runtime behavior affected.

## Checklist
- [x] Code follows project style guidelines
- [x] No breaking changes
- [x] Version consistent across platforms (iOS + Android)

## Related Issues
N/A