### PR TITLE
fix(theme): brighten dark-theme gain green for legible PnL contrast

### DIFF
--- a/composeApp/src/commonMain/kotlin/theme/Color.kt
+++ b/composeApp/src/commonMain/kotlin/theme/Color.kt
@@ -74,7 +74,7 @@ val surfaceContainerDark = Color(0xFF201F1F)
 val surfaceContainerHighDark = Color(0xFF2A2A29)
 val surfaceContainerHighestDark = Color(0xFF353534)
 
-val greenDark = Color(0xFF38761D)
+val greenDark = Color(0xFF66BB6A) // dark-theme gain green — kept bright for contrast on dark surfaces
 val greenLight = Color(0xFF4CAF50)
 val redDark = Color(0xFFF44336)
 val yellowDark = Color(0xFFFFEB3B)


### PR DESCRIPTION
## What

Brighten the dark-theme gain/positive color so the Portfolio hero card's PnL badge (and every other dark-theme gain display) is legible.

`greenDark` was `0xFF38761D` — a dark forest green rendered over the hero card's dark-olive surface (`primaryContainerDark = 0xFF33342E`). Measured contrast ≈ **2.26:1**, failing WCAG AA (needs 4.5:1). The naming was backwards: the dark-theme green was *darker* than the light-theme green (`greenLight = 0xFF4CAF50`) — the opposite of what dark mode wants.

## Change

One token in `theme/Color.kt`:

```kotlin
- val greenDark = Color(0xFF38761D)
+ val greenDark = Color(0xFF66BB6A) // dark-theme gain green — kept bright for contrast on dark surfaces
```

Material Green 400, ≈ **5.31:1** on the card.

## Why one line is enough

`greenDark`/`greenLight`/`redDark` are referenced **only** through the shared `getPriceChangeColor()` helper (`ui/utils/PriceUtils.kt`) — no direct usages anywhere. So this propagates to all dark-theme gains at once:

- Portfolio hero PnL pill (the reported bug)
- Coin-list % change
- Position PnL / ROE, allocation bars, tick-flash colors
- Chart gradient fills (`createPriceChangeGradientColors`)

## Scope / non-goals

- **Light theme:** untouched — it uses `greenLight`; `greenDark` is only returned when `isDarkTheme = true`.
- **Loss red** (`redDark = 0xFFF44336`, ~3.4:1): left unchanged this pass (deliberate).
- **Pre-existing inconsistency, not addressed here:** `CoinDetailScreen.kt:498-502` hardcodes `0xFF4CAF50` for gains regardless of theme, bypassing the helper — noted for a follow-up.

## Verification

- Contrast: **2.26:1 → 5.31:1** (WCAG AA pass) against `#33342E`.
- `./gradlew :composeApp:compileCommonMainKotlinMetadata` → BUILD SUCCESSFUL.
- Before/after visual check of the badge on the real card colors.
