### PR TITLE
[REFACTOR] Unify gain/loss colors into PriceChangeColors + AA-compliant light red

### DIFF
--- a/composeApp/src/commonMain/kotlin/theme/Color.kt
+++ b/composeApp/src/commonMain/kotlin/theme/Color.kt
@@ -74,8 +74,19 @@ val surfaceContainerDark = Color(0xFF201F1F)
 val surfaceContainerHighDark = Color(0xFF2A2A29)
 val surfaceContainerHighestDark = Color(0xFF353534)
 
-val greenDark = Color(0xFF66BB6A) // dark-theme gain green — kept bright for contrast on dark surfaces
-val greenLight = Color(0xFF4CAF50)
-val redDark = Color(0xFFF44336)
 val yellowDark = Color(0xFFFFEB3B)
 val yellowLight = Color(0xFFF57F17) // Darker yellow for light mode
+
+/** Semantic gain/loss colors for price changes, resolved per theme. */
+object PriceChangeColors {
+    /** Positive change. Brighter green on dark surfaces; standard green on light. */
+    fun gain(isDarkTheme: Boolean): Color = if (isDarkTheme) gainOnDark else gainOnLight
+
+    /** Negative change. Bright red on dark surfaces; darker AA-compliant red on light. */
+    fun loss(isDarkTheme: Boolean): Color = if (isDarkTheme) lossOnDark else lossOnLight
+
+    private val gainOnDark = Color(0xFF66BB6A)  // brighter green, kept legible on dark surfaces
+    private val gainOnLight = Color(0xFF4CAF50)
+    private val lossOnDark = Color(0xFFF44336)   // bright red, legible on dark surfaces
+    private val lossOnLight = Color(0xFFD32F2F)  // Material Red 700 — meets WCAG AA on light surfaces
+}

--- a/composeApp/src/commonMain/kotlin/ui/CoinDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/CoinDetailScreen.kt
@@ -74,6 +74,7 @@ import ui.components.LazyColumnScrollbar
 import ui.components.ScrollToEdgeButton
 import ui.components.TradingViewChart
 import ui.utils.debouncedClickable
+import ui.utils.getPriceChangeColor
 import ui.utils.isDarkTheme
 import ui.utils.shimmerEffect
 import utxo.composeapp.generated.resources.Res
@@ -298,7 +299,8 @@ fun CoinDetailScreen(
                                     PriceInfoSection(
                                         symbol = symbol,
                                         ticker = state.ticker,
-                                        tradingPairs = tradingPairs
+                                        tradingPairs = tradingPairs,
+                                        isDarkTheme = isDarkTheme
                                     )
                                 }
                             }
@@ -447,7 +449,8 @@ fun CoinDetailScreen(
 fun PriceInfoSection(
     symbol: String,
     ticker: Ticker24hr?,
-    tradingPairs: List<TradingPair> = emptyList()
+    tradingPairs: List<TradingPair> = emptyList(),
+    isDarkTheme: Boolean
 ) {
     var isExpanded by remember { mutableStateOf(false) }
 
@@ -495,11 +498,11 @@ fun PriceInfoSection(
                     Spacer(modifier = Modifier.height(4.dp))
 
                     val priceChangePercent = ticker.priceChangePercent.toDoubleOrNull() ?: 0.0
-                    val priceChangeColor = when {
-                        priceChangePercent > 0 -> Color(0xFF4CAF50) // Green
-                        priceChangePercent < 0 -> Color(0xFFF44336) // Red
-                        else -> MaterialTheme.colorScheme.onSurface
-                    }
+                    val priceChangeColor = getPriceChangeColor(
+                        ticker.priceChangePercent,
+                        isDarkTheme,
+                        MaterialTheme.colorScheme.onSurface
+                    )
 
                     PriceRow(
                         stringResource(Res.string.label_24h_change),

--- a/composeApp/src/commonMain/kotlin/ui/CoinDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/CoinDetailScreen.kt
@@ -299,8 +299,8 @@ fun CoinDetailScreen(
                                     PriceInfoSection(
                                         symbol = symbol,
                                         ticker = state.ticker,
-                                        tradingPairs = tradingPairs,
-                                        isDarkTheme = isDarkTheme
+                                        isDarkTheme = isDarkTheme,
+                                        tradingPairs = tradingPairs
                                     )
                                 }
                             }
@@ -449,8 +449,8 @@ fun CoinDetailScreen(
 fun PriceInfoSection(
     symbol: String,
     ticker: Ticker24hr?,
-    tradingPairs: List<TradingPair> = emptyList(),
-    isDarkTheme: Boolean
+    isDarkTheme: Boolean,
+    tradingPairs: List<TradingPair> = emptyList()
 ) {
     var isExpanded by remember { mutableStateOf(false) }
 

--- a/composeApp/src/commonMain/kotlin/ui/utils/PriceUtils.kt
+++ b/composeApp/src/commonMain/kotlin/ui/utils/PriceUtils.kt
@@ -1,9 +1,7 @@
 package ui.utils
 
 import androidx.compose.ui.graphics.Color
-import theme.greenDark
-import theme.greenLight
-import theme.redDark
+import theme.PriceChangeColors
 
 /**
  * Shared utilities for price-related calculations and color determination.
@@ -29,8 +27,8 @@ fun getPriceChangeColor(priceChangePercent: String, isDarkTheme: Boolean, primar
  */
 fun getPriceChangeColor(priceChangeFloat: Float, isDarkTheme: Boolean, primaryColor: Color): Color {
     return when {
-        priceChangeFloat > 0f -> if (isDarkTheme) greenDark else greenLight
-        priceChangeFloat < 0f -> redDark
+        priceChangeFloat > 0f -> PriceChangeColors.gain(isDarkTheme)
+        priceChangeFloat < 0f -> PriceChangeColors.loss(isDarkTheme)
         else -> primaryColor
     }
 }


### PR DESCRIPTION
## Description

Follow-up to the review notes on #287. Consolidates the gain/loss (green/red) price-change colors into a single semantic source of truth and closes the accessibility + naming gaps that review flagged as non-blocking.

Previously the palette exposed loose top-level vals `greenDark` / `greenLight` / `redDark` whose `Dark`/`Light` suffixes denote **theme, not shade** — misleading now that `greenDark` (0xFF66BB6A) is a *lighter* hex than `greenLight` (0xFF4CAF50). There was also no `redLight` at all, so the helper's loss branch was theme-blind (always `redDark`) while the gain branch was theme-aware — an asymmetry — and `redDark` measured only ~3.68:1 on light surfaces, below WCAG AA (4.5:1).

## Changes Made

- **`theme/Color.kt`** — Replace the three top-level vals with a semantic `PriceChangeColors` object exposing `gain(isDarkTheme)` / `loss(isDarkTheme)`. Add `lossOnLight = 0xFFD32F2F` (Material Red 700, ~4.99:1 on white — passes AA). Green hex values are unchanged; `yellowDark`/`yellowLight` untouched.
- **`ui/utils/PriceUtils.kt`** — Route `getPriceChangeColor` through the object. The loss branch is now theme-aware, resolving the asymmetry. **Public signatures are unchanged**, so all existing call sites (CryptoListScreen, PortfolioScreen) are untouched.
- **`ui/CoinDetailScreen.kt`** — Thread `isDarkTheme` into `PriceInfoSection` and replace the hardcoded `0xFF4CAF50`/`0xFFF44336` 24h-change block with `getPriceChangeColor(...)`, so it's theme-correct (brighter green in dark mode, AA red in light mode) like every other price surface.

## Type of Change
- [ ] New feature
- [x] Bug fix (theme-blind 24h-change color; sub-AA light-theme loss red)
- [x] Refactoring (semantic `PriceChangeColors`)
- [ ] Documentation update
- [ ] Performance improvement

## Testing Done
- [x] `./gradlew :composeApp:compileKotlinDesktop` — BUILD SUCCESSFUL
- [x] `./gradlew :composeApp:compileAndroidMain` (covers `androidMain`/widgets) — BUILD SUCCESSFUL
- [x] `./gradlew :composeApp:desktopTest` — BUILD SUCCESSFUL
- [x] AA verified by hand: `#D32F2F` on `#FFFFFF` ≈ 4.99:1 (passes AA ≥ 4.5:1)
- [ ] No new unit tests (pure color-token refactor; no new branching logic)

## Expected Visual Delta (nothing else moves)
- Light-theme loss red darkens everywhere the helper is used (`0xFFF44336 → 0xFFD32F2F`), including the losing-coin chart-fill gradient.
- CoinDetail 24h-change becomes theme-correct: dark-mode gain brightens `4CAF50 → 66BB6A`; light-mode loss darkens per above.
- Unchanged: all gains in both themes, dark-theme loss, and the pinned always-gain sites in PortfolioScreen.

## Out of Scope (deliberate)
- `OrderBookHeatMap` Binance bid/ask brand colors (`0xFF0ECB81`/`0xFFF6465D`) — different color language.
- Android widget helpers (`android.graphics.Color.parseColor`) — can't reach the commonMain Compose helper.
- `greenLight` AA (~2.8:1) — not flagged in review; changing it alters brand green. Noted as the next contrast gap.

## Checklist
- [x] Code follows project style guidelines (uses the shared helper; no hardcoded gain/loss colors)
- [x] Tests pass locally
- [x] No breaking changes (public helper signature preserved)

## Related
Follow-up to #287.
