### PR TITLE
[FEATURE] Add scroll-to-edge button and scrollbar to Portfolio screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/ui/PortfolioScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/PortfolioScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -91,6 +92,8 @@ import model.WalletTab
 import org.jetbrains.compose.resources.stringResource
 import theme.ThemeManager.store
 import ui.components.CoinIcon
+import ui.components.LazyColumnScrollbar
+import ui.components.ScrollToEdgeButton
 import ui.utils.bottomBarClearancePadding
 import ui.utils.getPriceChangeColor
 import ui.utils.isDarkTheme
@@ -282,6 +285,7 @@ private fun WalletScopeSwitcher(
 @Composable
 private fun PortfolioContent(data: PortfolioUiState.Data, isDark: Boolean, extraBottomPadding: Dp) {
     val palette = coinPalette()
+    val listState = rememberLazyListState()
     val showPerpStats = data.perpPositions.isNotEmpty() || data.summary.accountValue > 0.0
 
     // Allocation slices across USD-valued holdings (perp notionals + stable spot), largest first.
@@ -311,38 +315,48 @@ private fun PortfolioContent(data: PortfolioUiState.Data, isDark: Boolean, extra
         }
     }
 
-    LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 24.dp + extraBottomPadding),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        item(key = "hero") { HeroCard(data.summary, data.isStale, showPerpStats, isDark) }
+    Box(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 24.dp + extraBottomPadding),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item(key = "hero") { HeroCard(data.summary, data.isStale, showPerpStats, isDark) }
 
-        if (slices.size >= 2) {
-            item(key = "allocation") { AllocationSection(slices) }
+            if (slices.size >= 2) {
+                item(key = "allocation") { AllocationSection(slices) }
+            }
+
+            if (data.perpPositions.isNotEmpty()) {
+                item(key = "perp_header") {
+                    SectionHeader(stringResource(Res.string.portfolio_positions), data.perpPositions.size)
+                }
+                items(items = data.perpPositions, key = { "perp_${it.sourceLabel}_${it.coin}" }) { row ->
+                    PositionCard(row, palette.colorFor(row.coin), isDark)
+                }
+            }
+
+            if (data.spotBalances.isNotEmpty()) {
+                item(key = "spot_header") {
+                    SectionHeader(stringResource(Res.string.portfolio_spot), data.spotBalances.size)
+                }
+                items(items = data.spotBalances, key = { "spot_${it.sourceLabel}_${it.coin}" }) { row ->
+                    SpotCard(row, palette.colorFor(row.coin))
+                }
+            }
+
+            if (data.perpPositions.isEmpty() && data.spotBalances.isEmpty()) {
+                item(key = "empty") { EmptyHoldings() }
+            }
         }
 
-        if (data.perpPositions.isNotEmpty()) {
-            item(key = "perp_header") {
-                SectionHeader(stringResource(Res.string.portfolio_positions), data.perpPositions.size)
-            }
-            items(items = data.perpPositions, key = { "perp_${it.sourceLabel}_${it.coin}" }) { row ->
-                PositionCard(row, palette.colorFor(row.coin), isDark)
-            }
-        }
-
-        if (data.spotBalances.isNotEmpty()) {
-            item(key = "spot_header") {
-                SectionHeader(stringResource(Res.string.portfolio_spot), data.spotBalances.size)
-            }
-            items(items = data.spotBalances, key = { "spot_${it.sourceLabel}_${it.coin}" }) { row ->
-                SpotCard(row, palette.colorFor(row.coin))
-            }
-        }
-
-        if (data.perpPositions.isEmpty() && data.spotBalances.isEmpty()) {
-            item(key = "empty") { EmptyHoldings() }
-        }
+        LazyColumnScrollbar(listState = listState)
+        ScrollToEdgeButton(
+            listState = listState,
+            totalItems = listState.layoutInfo.totalItemsCount,
+            bottomBarClearance = extraBottomPadding,
+        )
     }
 }
 


### PR DESCRIPTION
## Description
The Portfolio screen was the only long-list screen missing the floating scroll-to-edge button (jump to top/bottom) and its companion scrollbar that the market list and coin-detail screens already have. This brings it to parity so users with many positions/balances can jump around the list without manual scrolling.

No new components were built — this reuses the existing `ScrollToEdgeButton` and `LazyColumnScrollbar` composables, wired in exactly as on `CoinDetailScreen`.

## Changes Made
- `composeApp/src/commonMain/kotlin/ui/PortfolioScreen.kt` (`PortfolioContent`):
  - Hoisted a `rememberLazyListState()` and passed it to the `LazyColumn` via `state =`.
  - Wrapped the `LazyColumn` in a `Box(Modifier.fillMaxSize())`.
  - Overlaid `LazyColumnScrollbar(listState)` and `ScrollToEdgeButton(listState, totalItems = listState.layoutInfo.totalItemsCount, bottomBarClearance = extraBottomPadding)` as siblings after the list.
  - Added imports: `rememberLazyListState`, `ui.components.LazyColumnScrollbar`, `ui.components.ScrollToEdgeButton`.
- No changes to the ViewModel or the reusable components.

## Behavior
- The button auto-hides when the list has 11 or fewer items.
- Near the top it shows a down-arrow and jumps to the last item; otherwise an up-arrow and jumps to the top (smooth `animateScrollToItem`).
- `bottomBarClearance` keeps the FAB clear of the iOS 26 glass tab bar.
- Only renders in the `PortfolioUiState.Data` branch (the one scrollable state).

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance improvement

## Testing Done
- [x] Desktop target compiles (`./gradlew :composeApp:compileKotlinDesktop`)
- [ ] Unit tests added/updated (UI wiring of an already-proven component; no new logic to unit-test)
- [x] Manual testing on Android
- [ ] Manual testing on iOS
- [ ] Manual testing on Desktop

## Checklist
- [x] Code follows project style guidelines (mirrors existing call sites)
- [x] Reuses existing shared components (no new UI primitives)
- [x] No breaking changes