### PR TITLE
chore(release): bump version to 0.4.10 (Android) / 0.4.11 (iOS)

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -443,7 +443,7 @@
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 49;
+				CURRENT_PROJECT_VERSION = 51;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = 37UYJHD27F;
 				ENABLE_PREVIEWS = YES;
@@ -459,7 +459,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.9;
+				MARKETING_VERSION = 0.4.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = org.androdevlinux.utxo.UTXO;
 				PRODUCT_NAME = "${APP_NAME}";
@@ -477,7 +477,7 @@
 				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 49;
+				CURRENT_PROJECT_VERSION = 51;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
 				DEVELOPMENT_TEAM = 37UYJHD27F;
 				ENABLE_PREVIEWS = YES;
@@ -493,7 +493,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.4.9;
+				MARKETING_VERSION = 0.4.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				"PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*]" = org.androdevlinux.utxo.UTXO;
 				PRODUCT_NAME = "${APP_NAME}";

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,2 @@
-versionName=0.4.9
-versionCode=409
+versionName=0.4.10
+versionCode=410


### PR DESCRIPTION
## Summary

Release version bump across platforms.

| Platform | Field | Before | After |
|----------|-------|--------|-------|
| Android  | `versionName` | 0.4.9 | 0.4.10 |
| Android  | `versionCode` | 409 | 410 |
| iOS      | `MARKETING_VERSION` | 0.4.9 | 0.4.11 |
| iOS      | `CURRENT_PROJECT_VERSION` | 49 | 51 |

## Notes

- Files touched: `version.properties`, `iosApp/iosApp.xcodeproj/project.pbxproj`.
- iOS marketing version (0.4.11) is one patch ahead of Android (0.4.10) — reflecting an extra iOS build in this cycle.

## Test plan

- No functional code changes; metadata/version bump only.