### PR TITLE
[FIX] Stop false "Network Unavailable" dialog on iOS widget cold start

### DIFF
--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -224,7 +224,10 @@ fun App(
         }
     }
 
-    if (networkStatus != NetworkStatus.Available) {
+    // Only block on a *confirmed* offline status. `null` is the not-yet-determined seed emitted
+    // before the connectivity observer's first callback; treating it as offline flashed a false
+    // "Network Unavailable" dialog on cold start (worst on the iOS widget deep-link path).
+    if (networkStatus == NetworkStatus.Unavailable) {
         NetworkDialog()
     }
 

--- a/composeApp/src/iosMain/kotlin/App.ios.kt
+++ b/composeApp/src/iosMain/kotlin/App.ios.kt
@@ -12,9 +12,13 @@ import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.io.files.Path
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
@@ -57,6 +61,7 @@ actual fun openLink(link: String) {
 
 
 actual class NetworkConnectivityObserver {
+    @OptIn(ExperimentalCoroutinesApi::class)
     actual fun observe(): Flow<NetworkStatus?> = callbackFlow {
         val monitor = nw_path_monitor_create()
         val queue = dispatch_queue_create(
@@ -81,6 +86,16 @@ actual class NetworkConnectivityObserver {
             nw_path_monitor_cancel(monitor)
         }
     }
+        .distinctUntilChanged()
+        // Debounce a transient offline flap: launching off a *locked* device (e.g. a lockscreen
+        // widget deep-link) can make NWPathMonitor briefly report `.unsatisfied` before it settles
+        // to `.satisfied`. mapLatest cancels the pending delay the instant a newer status arrives,
+        // so `Available` still propagates immediately and only a sustained (>1.5s) offline reaches
+        // the UI — no false "Network Unavailable" dialog on cold start.
+        .mapLatest { status ->
+            if (status == NetworkStatus.Unavailable) delay(1500)
+            status
+        }
 }
 
 @OptIn(ExperimentalForeignApi::class)

--- a/composeApp/src/iosMain/kotlin/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/MainViewController.kt
@@ -53,7 +53,10 @@ private fun IosScreen(content: @Composable () -> Unit) {
     val status by IosShared.networkStatus.collectAsState()
     UTXOTheme(isDarkTheme(settings)) {
         content()
-        if (status != NetworkStatus.Available) NetworkDialog()
+        // Only block on a *confirmed* offline status. `null` is the not-yet-determined seed
+        // (cold start before the monitor's first callback) — treating it as offline flashed a
+        // false "Network Unavailable" dialog when deep-linking from the widget. See App.ios.kt.
+        if (status == NetworkStatus.Unavailable) NetworkDialog()
     }
 }
 


### PR DESCRIPTION
## Description

On iOS 26, tapping a favorite on the **lockscreen widget** deep-links into the app (`utxo://coin/<symbol>`) and cold-starts it straight onto the coin-detail screen — where a blocking, non-dismissible **"Network Unavailable"** dialog appears even though the network is up. The screenshot that triggered this fix shows chart candles and live prices rendering *behind* the dialog, i.e. the REST fetch and WebSocket both succeeded — a false positive.

### Root cause

The dialog was gated purely on the connectivity monitor and treated the initial *unknown* (`null`) value as offline:

```kotlin
if (status != NetworkStatus.Available) NetworkDialog()   // null != Available → true → dialog shows
```

`IosShared.networkStatus` starts at `null` and only flips once `NWPathMonitor` fires its first callback. The widget path is the worst case: a **cold start**, and a launch off a *locked* device can make `NWPathMonitor` briefly report `.unsatisfied` before settling to `.satisfied`.

## Changes Made

- **`MainViewController.kt`** (iOS 26 path) and **`App.kt`** (iOS <26 fallback + Android/desktop/web): gate the dialog on a *confirmed* `NetworkStatus.Unavailable`. `null`/unknown now means "assume online" instead of "offline". Safe on every platform — all observers emit a concrete status; `null` is only the pre-first-callback seed. Android also stops flashing the dialog on cold start as a bonus.
- **`App.ios.kt`**: debounce a transient offline flap in the `NWPathMonitor` observer via `distinctUntilChanged()` + `mapLatest { delay(1500) }`, so a locked-launch `.unsatisfied` that settles to `.satisfied` within ~1.5s never reaches the UI. `Available` still propagates immediately; genuine offline still warns after the debounce.

## Type of Change
- [x] Bug fix

## Testing Done
- [x] `./gradlew :composeApp:compileKotlinIosSimulatorArm64` — BUILD SUCCESSFUL (type-checks iosMain + commonMain)
- [ ] Manual testing on iOS device/simulator — **pending**: cold-start from lockscreen widget with working network → no dialog; Airplane Mode → dialog appears after debounce; toggling connectivity in-app still works
- [ ] Manual testing on Android

## Checklist
- [x] Code follows project style guidelines
- [x] No breaking changes
- [ ] Manual device verification pending (see Testing Done)

## Notes
Deliberately out of scope (follow-ups): consolidating the three independent `NetworkConnectivityObserver` instances into one shared iOS source, and adding a Retry affordance to `NetworkDialog`.