### PR TITLE
[PERFORMANCE] Cut per-tick main-thread work and UI jank on live surfaces

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -47,15 +47,6 @@ plugins {
 }
 
 kotlin {
-    compilerOptions {
-        freeCompilerArgs.addAll(
-            listOf(
-                "-XXLanguage:+ExplicitBackingFields",
-                "-Xexplicit-backing-fields"
-            )
-        )
-    }
-
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
         browser()

--- a/composeApp/src/commonMain/kotlin/ktx/DoubleKtx.kt
+++ b/composeApp/src/commonMain/kotlin/ktx/DoubleKtx.kt
@@ -8,8 +8,29 @@ fun Double.formatAsCurrency(): String {
     val integerPart = absValue.toLong()
     val fractionalPart = ((absValue - integerPart) * 100).roundToInt()
 
-    val formattedInteger = integerPart.toString().reversed().chunked(3).joinToString(",").reversed()
+    val formattedInteger = groupThousands(integerPart)
     val formattedFractional = fractionalPart.toString().padStart(2, '0')
 
     return if (this < 0) "-$formattedInteger.$formattedFractional" else "$formattedInteger.$formattedFractional"
+}
+
+/**
+ * Inserts thousands separators in a single pass. Replaces the
+ * `toString().reversed().chunked(3).joinToString(",").reversed()` idiom (which allocated several
+ * intermediate strings + a list per call) — this runs while formatting prices for the whole
+ * market on every ticker frame. Expects a non-negative value.
+ */
+internal fun groupThousands(value: Long): String {
+    val s = value.toString()
+    if (s.length <= 3) return s
+    val sb = StringBuilder(s.length + (s.length - 1) / 3)
+    val firstGroup = s.length % 3
+    if (firstGroup > 0) sb.append(s, 0, firstGroup)
+    var i = firstGroup
+    while (i < s.length) {
+        if (sb.isNotEmpty()) sb.append(',')
+        sb.append(s, i, i + 3)
+        i += 3
+    }
+    return sb.toString()
 }

--- a/composeApp/src/commonMain/kotlin/ktx/StringKtx.kt
+++ b/composeApp/src/commonMain/kotlin/ktx/StringKtx.kt
@@ -68,13 +68,7 @@ fun String.formatVolume(): String {
                 }
             }
 
-            value >= 1_000 -> {
-                value.roundToInt().toString()
-                    .reversed()
-                    .chunked(3)
-                    .joinToString(",")
-                    .reversed()
-            }
+            value >= 1_000 -> groupThousands(value.roundToInt().toLong())
 
             value >= 1 -> {
                 "${(value * 100).roundToInt() / 100.0}"

--- a/composeApp/src/commonMain/kotlin/model/OrderBook.kt
+++ b/composeApp/src/commonMain/kotlin/model/OrderBook.kt
@@ -59,5 +59,21 @@ data class OrderBookData(
         val ask = bestAsk?.priceDouble ?: return null
         return (bid + ask) / 2.0
     }
+
+    // Equality intentionally ignores lastUpdateId/timestamp (which change on every emission even when
+    // the visible book is unchanged). This lets the backing StateFlow conflate no-op updates so the
+    // order book UI doesn't recompose ~1x/sec for an identical book. Neither field is read by the UI.
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is OrderBookData) return false
+        return symbol == other.symbol && bids == other.bids && asks == other.asks
+    }
+
+    override fun hashCode(): Int {
+        var result = symbol.hashCode()
+        result = 31 * result + bids.hashCode()
+        result = 31 * result + asks.hashCode()
+        return result
+    }
 }
 

--- a/composeApp/src/commonMain/kotlin/network/OrderBookWebSocketService.kt
+++ b/composeApp/src/commonMain/kotlin/network/OrderBookWebSocketService.kt
@@ -145,10 +145,11 @@ class OrderBookWebSocketService {
                             continue // Continue loop to reconnect
                         }
                     } catch (e: CancellationException) {
+                        // Expected on disconnect/teardown — breadcrumb only, no JobCancellationException dump.
                         isConnected = false
                         needsReconnect = false
-                        AppLogger.logger.d(throwable = e) { 
-                            "OrderBookWebSocket: Connection cancelled for $symbol" 
+                        AppLogger.logger.d {
+                            "OrderBookWebSocket: Connection cancelled for $symbol"
                         }
                         break
                     } catch (e: Exception) {

--- a/composeApp/src/commonMain/kotlin/network/TickerWebSocketService.kt
+++ b/composeApp/src/commonMain/kotlin/network/TickerWebSocketService.kt
@@ -108,10 +108,9 @@ class TickerWebSocketService {
                         }
                         isConnected = false
                     } catch (e: CancellationException) {
+                        // Expected on disconnect/teardown — breadcrumb only, no JobCancellationException dump.
                         isConnected = false
-                        AppLogger.logger.d(throwable = e) { 
-                            "TickerWebSocket: Connection cancelled for $symbol" 
-                        }
+                        AppLogger.logger.d { "TickerWebSocket: Connection cancelled for $symbol" }
                         break
                     } catch (e: Exception) {
                         isConnected = false

--- a/composeApp/src/commonMain/kotlin/ui/CoinDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/CoinDetailScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -369,8 +370,10 @@ fun CoinDetailScreen(
                                     }
                                 }
                             } else {
-                                // Show news items as they arrive
-                                items(state.news) { newsItem ->
+                                // Show news items as they arrive. Stable key (link) so Compose moves
+                                // existing cards across the re-sort on each provider append instead of
+                                // rebuilding every NewsItemCard (re-parsing dates, re-laying-out text).
+                                items(state.news, key = { it.link }) { newsItem ->
                                     NewsItemCard(
                                         newsItem = newsItem,
                                         isDarkTheme = isDarkTheme
@@ -432,9 +435,14 @@ fun CoinDetailScreen(
                             }
                         }
                         LazyColumnScrollbar(listState = listState)
+                        // Gate the totalItemsCount read behind derivedStateOf so scrolling only
+                        // re-triggers this button when the item COUNT changes, not every scroll frame.
+                        val scrollTotal by remember(listState) {
+                            derivedStateOf { listState.layoutInfo.totalItemsCount }
+                        }
                         ScrollToEdgeButton(
                             listState = listState,
-                            totalItems = listState.layoutInfo.totalItemsCount
+                            totalItems = scrollTotal
                         )
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/ui/CryptoListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/CryptoListScreen.kt
@@ -1,6 +1,7 @@
 package ui
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
@@ -158,36 +159,40 @@ fun CryptoList(
     val tradingPairs by cryptoViewModel.tradingPairs.collectAsState()
     val settingsStore by store.updates.collectAsState(initial = null)
     
-    // Derive stable list of ticker items to avoid recreating list on every recomposition
-    val tickerItems by derivedStateOf { tickerDataMap.values.toList() }
-    
+    // Derive stable list of ticker items to avoid recreating list on every recomposition.
+    // remember { derivedStateOf { } } so the derived state is created once and only recomputes
+    // (and notifies readers) when its snapshot inputs actually change.
+    val tickerItems by remember { derivedStateOf { tickerDataMap.values.toList() } }
+
     // Derive stable trading pair list
-    val tradingPairList by derivedStateOf { tradingPairs.map { it.quote } }
-    
-    val currentTradingPair by derivedStateOf { settingsStore?.selectedTradingPair ?: "BTC" }
+    val tradingPairList by remember { derivedStateOf { tradingPairs.map { it.quote } } }
+
+    val currentTradingPair by remember { derivedStateOf { settingsStore?.selectedTradingPair ?: "BTC" } }
 
     // Optimize visible symbols calculation - use derivedStateOf for automatic recomposition only when needed
-    val visibleSymbols by derivedStateOf {
-        val layoutInfo = listState.layoutInfo
-        if (tickerItems.isEmpty() || layoutInfo.visibleItemsInfo.isEmpty()) {
-            return@derivedStateOf emptyList()
-        }
+    val visibleSymbols by remember {
+        derivedStateOf {
+            val layoutInfo = listState.layoutInfo
+            if (tickerItems.isEmpty() || layoutInfo.visibleItemsInfo.isEmpty()) {
+                return@derivedStateOf emptyList()
+            }
 
-        val prefetchBuffer = 10
-        val visibleIndices = layoutInfo.visibleItemsInfo.map { it.index }
+            val prefetchBuffer = 10
+            val visibleIndices = layoutInfo.visibleItemsInfo.map { it.index }
 
-        val startIndex = visibleIndices.minOrNull()
-            ?.minus(prefetchBuffer)
-            ?.coerceAtLeast(0)
-            ?: 0
+            val startIndex = visibleIndices.minOrNull()
+                ?.minus(prefetchBuffer)
+                ?.coerceAtLeast(0)
+                ?: 0
 
-        val endIndex = visibleIndices.maxOrNull()
-            ?.plus(prefetchBuffer)
-            ?.coerceAtMost(tickerItems.lastIndex)
-            ?: tickerItems.lastIndex
+            val endIndex = visibleIndices.maxOrNull()
+                ?.plus(prefetchBuffer)
+                ?.coerceAtMost(tickerItems.lastIndex)
+                ?: tickerItems.lastIndex
 
-        (startIndex..endIndex).mapNotNull { index ->
-            tickerItems.getOrNull(index)?.symbol
+            (startIndex..endIndex).mapNotNull { index ->
+                tickerItems.getOrNull(index)?.symbol
+            }
         }
     }
 
@@ -955,20 +960,14 @@ fun TickerCard(
                             )
                         }
                         Spacer(Modifier.height(4.dp))
-                        AnimatedContent(
-                            targetState = formattedVolume,
-                            transitionSpec = { fadeIn() togetherWith fadeOut() },
-                            label = "volume Animation"
-                        ) { targetVolume ->
-                            Text(
-                                text = targetVolume,
-                                style = MaterialTheme.typography.labelMedium,
-                                color = Color.Gray,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.animateContentSize()
-                            )
-                        }
+                        // Plain Text (no per-tick crossfade/relayout); volume is informational.
+                        Text(
+                            text = formattedVolume,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = Color.Gray,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
                     }
                 }
                 TradeChart(trades = trades, priceChangePercent = priceChangePercent)
@@ -984,34 +983,38 @@ fun TickerCard(
                         horizontalAlignment = Alignment.End,
                         verticalArrangement = Arrangement.Center
                     ) {
-                        AnimatedContent(
-                            targetState = priceChangePercent,
-                            transitionSpec = { fadeIn() togetherWith fadeOut() },
-                            label = "Price Change Percentage Animation"
-                        ) { targetPriceChangePercent ->
-                            val priceChangeColor = getPriceChangeColor(
-                                targetPriceChangePercent,
-                                isDarkTheme,
-                                MaterialTheme.colorScheme.primary
-                            )
-                            Text(
-                                modifier = Modifier.animateContentSize().padding(bottom = 8.dp),
-                                text = "$targetPriceChangePercent %",
-                                color = priceChangeColor,
-                                style = MaterialTheme.typography.titleSmall
-                            )
+                        // %-change: plain Text; the green/red sign color is the persistent affordance.
+                        val priceChangeColor = getPriceChangeColor(
+                            priceChangePercent,
+                            isDarkTheme,
+                            MaterialTheme.colorScheme.primary
+                        )
+                        Text(
+                            modifier = Modifier.padding(bottom = 8.dp),
+                            text = "$priceChangePercent %",
+                            color = priceChangeColor,
+                            style = MaterialTheme.typography.titleSmall
+                        )
+                        // Brief color flash on each price change preserves the "value updated"
+                        // feedback the old crossfade gave — a draw-phase color animation with no relayout.
+                        val defaultPriceColor = MaterialTheme.colorScheme.onSurface
+                        var priceFlashing by remember { mutableStateOf(false) }
+                        LaunchedEffect(tickerData.lastPrice) {
+                            priceFlashing = true
+                            delay(220)
+                            priceFlashing = false
                         }
-                        AnimatedContent(
-                            targetState = tickerData.lastPrice,
-                            transitionSpec = { fadeIn() togetherWith fadeOut() },
-                            label = "Price Animation"
-                        ) { targetPrice ->
-                            Text(
-                                text = targetPrice,
-                                style = MaterialTheme.typography.titleSmall,
-                                modifier = Modifier.animateContentSize().padding(bottom = 8.dp),
-                            )
-                        }
+                        val priceColor by animateColorAsState(
+                            targetValue = if (priceFlashing) priceChangeColor else defaultPriceColor,
+                            animationSpec = tween(220),
+                            label = "TickerCardPriceFlash"
+                        )
+                        Text(
+                            text = tickerData.lastPrice,
+                            color = priceColor,
+                            style = MaterialTheme.typography.titleSmall,
+                            modifier = Modifier.padding(bottom = 8.dp),
+                        )
                     }
                 }
             }
@@ -1064,24 +1067,27 @@ fun FavoritesListScreen(
     val listState = rememberLazyListState()
     val settingsStore by store.updates.collectAsState(initial = null)
     
-    // Derive stable list to avoid recreating on every recomposition
-    val tickerItems by derivedStateOf { tickerDataMap.values.toList() }
-    val currentTradingPair by derivedStateOf { settingsStore?.selectedTradingPair ?: "BTC" }
-    
+    // Derive stable list to avoid recreating on every recomposition.
+    // remember { derivedStateOf { } } so the derived state caches and only recomputes on real input changes.
+    val tickerItems by remember { derivedStateOf { tickerDataMap.values.toList() } }
+    val currentTradingPair by remember { derivedStateOf { settingsStore?.selectedTradingPair ?: "BTC" } }
+
     // Track fetch job for cancellation
     var fetchJob by remember { mutableStateOf<Job?>(null) }
-    
+
     // Calculate visible symbols for lifecycle-aware fetching
-    val visibleSymbols by derivedStateOf {
-        val layoutInfo = listState.layoutInfo
-        if (tickerItems.isEmpty() || layoutInfo.visibleItemsInfo.isEmpty()) {
-            return@derivedStateOf emptyList()
+    val visibleSymbols by remember {
+        derivedStateOf {
+            val layoutInfo = listState.layoutInfo
+            if (tickerItems.isEmpty() || layoutInfo.visibleItemsInfo.isEmpty()) {
+                return@derivedStateOf emptyList()
+            }
+            val prefetchBuffer = 10
+            val visibleIndices = layoutInfo.visibleItemsInfo.map { it.index }
+            val startIndex = visibleIndices.minOrNull()?.minus(prefetchBuffer)?.coerceAtLeast(0) ?: 0
+            val endIndex = visibleIndices.maxOrNull()?.plus(prefetchBuffer)?.coerceAtMost(tickerItems.lastIndex) ?: tickerItems.lastIndex
+            (startIndex..endIndex).mapNotNull { index -> tickerItems.getOrNull(index)?.symbol }
         }
-        val prefetchBuffer = 10
-        val visibleIndices = layoutInfo.visibleItemsInfo.map { it.index }
-        val startIndex = visibleIndices.minOrNull()?.minus(prefetchBuffer)?.coerceAtLeast(0) ?: 0
-        val endIndex = visibleIndices.maxOrNull()?.plus(prefetchBuffer)?.coerceAtMost(tickerItems.lastIndex) ?: tickerItems.lastIndex
-        (startIndex..endIndex).mapNotNull { index -> tickerItems.getOrNull(index)?.symbol }
     }
     
     // Lifecycle-aware data fetching with cancellation
@@ -1217,13 +1223,15 @@ fun FavoritesListScreen(
                                     bottom = bottomBarClearancePadding(bottomBarClearance),
                                 ),
                             ) {
+                                // Leading spacer as its own item (matches the Market list) instead of
+                                // an O(n) indexOf inside every row body — that was O(n^2) per update.
+                                item(key = "spacer_top") {
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                }
                                 items(
                                     items = tickerItems,
                                     key = { it.symbol } // Stable key for efficient recomposition
                                 ) { tickerData ->
-                                    if (tickerItems.indexOf(tickerData) == 0) {
-                                        Spacer(modifier = Modifier.height(4.dp))
-                                    }
                                     TickerCard(
                                         tickerData = tickerData,
                                         selectedTradingPair = currentTradingPair,

--- a/composeApp/src/commonMain/kotlin/ui/CryptoViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/ui/CryptoViewModel.kt
@@ -438,7 +438,7 @@ class CryptoViewModel : ViewModel() {
                     }
                 }
             } catch (e: CancellationException) {
-                AppLogger.logger.d(throwable = e) { "Cancelled fetching favorites prices" }
+                AppLogger.logger.d { "Cancelled fetching favorites prices" }
             } catch (e: Exception) {
                 AppLogger.logger.e(throwable = e) { "Error fetching favorites prices" }
             }
@@ -491,8 +491,10 @@ class CryptoViewModel : ViewModel() {
                         }
                         isWebSocketConnected = false
                     } catch (e: CancellationException) {
+                        // Expected on reconnect/pause/teardown — log a breadcrumb without the
+                        // JobCancellationException stacktrace ("StandaloneCoroutine was cancelled").
                         isWebSocketConnected = false
-                        AppLogger.logger.d(throwable = e) { "WebSocket connection cancelled" }
+                        AppLogger.logger.d { "WebSocket connection cancelled" }
                     } catch (e: Exception) {
                         isWebSocketConnected = false
                         if (isActive) {
@@ -581,6 +583,10 @@ class CryptoViewModel : ViewModel() {
                 updateDisplayedPairs()
             }
         }.onFailure {
+            // Cancellation is normal on teardown/reconnect — propagate it instead of logging it
+            // as an error (runCatching would otherwise swallow it and ship a spurious
+            // "StandaloneCoroutine was cancelled" trace via ServerLogWriter).
+            if (it is CancellationException) throw it
             AppLogger.logger.e(throwable = it) { "Error processing ticker message" }
         }
     }

--- a/composeApp/src/commonMain/kotlin/ui/CryptoViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/ui/CryptoViewModel.kt
@@ -17,6 +17,7 @@ import io.ktor.websocket.readText
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -24,6 +25,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -43,8 +45,6 @@ import theme.ThemeManager.store
 import syncSettingsToWidget
 import kotlin.math.abs
 import kotlin.math.round
-import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
 
 private val STABLECOINS = setOf(
     "USDT", "USDC", "BUSD", "DAI", "TUSD", "FDUSD",
@@ -75,8 +75,11 @@ class CryptoViewModel : ViewModel() {
         field = MutableStateFlow("")
 
     private var webSocketJob: Job? = null
-    private var lastUpdateTime = 0L
-    private val updateThrottleMs = 250L
+    // Single conflated inbox for raw ticker frames. The socket read loop only trySend()s here;
+    // one long-lived consumer drains it (see startTickerProcessor). Conflation coalesces bursts to
+    // the latest frame, replacing the old per-frame coroutine launch + manual time throttle.
+    private val tickerMessages = Channel<String>(Channel.CONFLATED)
+    private val maxTradesPerSymbol = 200
     private val settings = store.updates
 
     val currentSortKey = mutableStateOf(SortParams.Vol)
@@ -163,7 +166,7 @@ class CryptoViewModel : ViewModel() {
         val finalList = sortedFavorites + sortedNonFavorites
         
         finalList.associateBy { it.symbol }
-    }.stateIn(
+    }.flowOn(Dispatchers.Default).stateIn(
         viewModelScope,
         SharingStarted.Eagerly,
         emptyMap()
@@ -198,7 +201,7 @@ class CryptoViewModel : ViewModel() {
         }
         
         sortedFavorites.associateBy { it.symbol }
-    }.stateIn(
+    }.flowOn(Dispatchers.Default).stateIn(
         viewModelScope,
         SharingStarted.Eagerly,
         emptyMap()
@@ -239,6 +242,7 @@ class CryptoViewModel : ViewModel() {
     }
 
     init {
+        startTickerProcessor()
         initializeData()
         observeNetworkChanges()
     }
@@ -473,8 +477,8 @@ class CryptoViewModel : ViewModel() {
                                 }
                                 when (frame) {
                                     is Frame.Text -> {
-                                        // Process message off main thread
-                                        processTickerMessage(frame.readText())
+                                        // Non-blocking hand-off to the single conflated processor.
+                                        tickerMessages.trySend(frame.readText())
                                     }
                                     is Frame.Ping -> send(Frame.Pong(frame.data))
                                     is Frame.Close -> {
@@ -522,56 +526,62 @@ class CryptoViewModel : ViewModel() {
         return (round(pct * 100.0) / 100.0).toString()
     }
 
-    @OptIn(ExperimentalTime::class)
-    private fun processTickerMessage(message: String) {
-        val now = Clock.System.now().toEpochMilliseconds()
-        if (now - lastUpdateTime < updateThrottleMs) return
-        lastUpdateTime = now
-
+    private fun startTickerProcessor() {
+        // One long-lived consumer draining the conflated inbox. Replaces launching a coroutine per
+        // frame (which raced on read-modify-write of allTickerDataMap/trades, losing writes) and the
+        // manual 250ms time throttle (conflation provides backpressure instead).
         viewModelScope.launch(Dispatchers.Default) {
-            runCatching {
-                // Parse JSON off main thread
-                val tickers = Json.decodeFromString<List<MiniTicker>>(message)
-                val currentTradingPairs = tradingPairs.value
-                
-                // Process all data off main thread
-                val updatedTickerMap = allTickerDataMap.value.toMutableMap()
-                val updatedTrades = trades.value.toMutableMap()
-                
-                tickers.forEach { ticker ->
-                    val formattedPrice = ticker.closePrice.formatPrice(ticker.symbol, currentTradingPairs)
-                    updatedTickerMap[ticker.symbol] = TickerData(
-                        symbol = ticker.symbol,
-                        lastPrice = formattedPrice,
-                        priceChangePercent = priceChangePercentFromOpenClose(
-                            ticker.openPrice,
-                            ticker.closePrice
-                        ),
-                        volume = ticker.totalTradedQuoteAssetVolume
-                    )
-                    
-                    // Update trades efficiently - limit to reduce memory pressure on iOS
-                    // Keep only last 200 points (enough for smooth charts, reduces memory)
-                    val maxTradesPerSymbol = 200
-                    val currentTrades = updatedTrades[ticker.symbol] ?: emptyList()
+            for (message in tickerMessages) {
+                processTickerMessageInternal(message)
+            }
+        }
+    }
+
+    private suspend fun processTickerMessageInternal(message: String) {
+        runCatching {
+            // Parse JSON off the main thread
+            val tickers = Json.decodeFromString<List<MiniTicker>>(message)
+            val currentTradingPairs = tradingPairs.value
+
+            // Process all data off main thread
+            val updatedTickerMap = allTickerDataMap.value.toMutableMap()
+            val updatedTrades = trades.value.toMutableMap()
+
+            tickers.forEach { ticker ->
+                val formattedPrice = ticker.closePrice.formatPrice(ticker.symbol, currentTradingPairs)
+                updatedTickerMap[ticker.symbol] = TickerData(
+                    symbol = ticker.symbol,
+                    lastPrice = formattedPrice,
+                    priceChangePercent = priceChangePercentFromOpenClose(
+                        ticker.openPrice,
+                        ticker.closePrice
+                    ),
+                    volume = ticker.totalTradedQuoteAssetVolume
+                )
+
+                // Only extend sparkline history for symbols the UI is ALREADY charting (seeded via
+                // REST when they became visible). Previously this grew a fresh up-to-200-element list
+                // for the whole ~1400-symbol universe every tick — the dominant allocation source.
+                val currentTrades = updatedTrades[ticker.symbol]
+                if (currentTrades != null) {
                     updatedTrades[ticker.symbol] = if (currentTrades.size >= maxTradesPerSymbol) {
-                        // Use drop + add instead of creating new list to reduce allocations
                         currentTrades.drop(1) + UiKline(closePrice = ticker.closePrice)
                     } else {
                         currentTrades + UiKline(closePrice = ticker.closePrice)
                     }
                 }
-
-                // Update state on main thread - limit trades to visible symbols only to reduce memory
-                withContext(Dispatchers.Main) {
-                    allTickerDataMap.value = updatedTickerMap
-                    // Only keep trades with enough data points, and limit to reduce memory pressure
-                    trades.value = updatedTrades.filterValues { it.size > 50 }
-                    updateDisplayedPairs()
-                }
-            }.onFailure {
-                AppLogger.logger.e(throwable = it) { "Error processing ticker message" }
             }
+
+            // Prune off the main thread; only the state assignment happens on Main.
+            val prunedTrades = updatedTrades.filterValues { it.size > 50 }
+
+            withContext(Dispatchers.Main) {
+                allTickerDataMap.value = updatedTickerMap
+                trades.value = prunedTrades
+                updateDisplayedPairs()
+            }
+        }.onFailure {
+            AppLogger.logger.e(throwable = it) { "Error processing ticker message" }
         }
     }
 
@@ -579,6 +589,7 @@ class CryptoViewModel : ViewModel() {
         // Cancel all background jobs to prevent memory leaks
         webSocketJob?.cancel()
         fetchJob?.cancel()
+        tickerMessages.close()
 
         // Close HTTP client (this is per-ViewModel instance)
         try {

--- a/composeApp/src/commonMain/kotlin/ui/OrderBookHeatMap.kt
+++ b/composeApp/src/commonMain/kotlin/ui/OrderBookHeatMap.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -33,6 +32,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -408,10 +409,8 @@ private fun OrderBookList(
                 ) {
                     if (index < groupedBids.size) {
                         val level = groupedBids[index]
-                        val depthRatio by remember(level.quantity, maxQty) {
-                            derivedStateOf {
-                                if (maxQty > 0) (level.quantity / maxQty).coerceIn(0.0, 1.0) else 0.0
-                            }
+                        val depthRatio = remember(level.quantity, maxQty) {
+                            if (maxQty > 0) (level.quantity / maxQty).coerceIn(0.0, 1.0) else 0.0
                         }
                         
                         OrderBookRow(
@@ -435,10 +434,8 @@ private fun OrderBookList(
                 ) {
                     if (index < groupedAsks.size) {
                         val level = groupedAsks[index]
-                        val depthRatio by remember(level.quantity, maxQty) {
-                            derivedStateOf {
-                                if (maxQty > 0) (level.quantity / maxQty).coerceIn(0.0, 1.0) else 0.0
-                            }
+                        val depthRatio = remember(level.quantity, maxQty) {
+                            if (maxQty > 0) (level.quantity / maxQty).coerceIn(0.0, 1.0) else 0.0
                         }
                         
                         OrderBookRow(
@@ -499,16 +496,22 @@ private fun OrderBookRow(
         modifier = modifier,
         contentAlignment = Alignment.Center
     ) {
-        // Depth bar: grows OUTWARD from center
+        // Depth bar: grows OUTWARD from center.
+        // Animate the width in the draw phase (scaleX) rather than the layout phase
+        // (fillMaxWidth(fraction)), so the spring never remeasures/relayouts the row. The
+        // transformOrigin anchors growth to the outer edge (buy = right, sell = left).
         Box(
             modifier = Modifier
                 .fillMaxHeight()
-                .fillMaxWidth(animatedBarWidth)
+                .fillMaxWidth()
+                .graphicsLayer {
+                    scaleX = animatedBarWidth
+                    transformOrigin = TransformOrigin(if (isBuy) 1f else 0f, 0.5f)
+                }
                 .background(
                     if (isBuy) buyColor.copy(alpha = barAlpha)
                     else sellColor.copy(alpha = barAlpha)
                 )
-                .align(if (isBuy) Alignment.CenterEnd else Alignment.CenterStart)
         )
         
         // Text layer

--- a/composeApp/src/commonMain/kotlin/ui/PortfolioScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/PortfolioScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -294,7 +295,9 @@ private fun PortfolioContent(data: PortfolioUiState.Data, isDark: Boolean, extra
     // Each slice keeps a stable id (instrument+coin+wallet) so the same coin held across several
     // wallets stays independently selectable in the aggregate "All" view. Color/fraction are filled
     // after sorting, so the seeds are built with placeholders.
-    val slices = run {
+    // remember keyed on the only inputs that affect the breakdown, so it is NOT rebuilt+sorted
+    // inside composition on every unrelated recomposition (scroll frames) or no-op price tick.
+    val slices = remember(data.perpPositions, data.spotBalances, palette) {
         val seeds = buildList {
             data.perpPositions.forEach {
                 if (it.notionalUsd > 0.0) {
@@ -352,9 +355,14 @@ private fun PortfolioContent(data: PortfolioUiState.Data, isDark: Boolean, extra
         }
 
         LazyColumnScrollbar(listState = listState)
+        // Gate the totalItemsCount read behind derivedStateOf so scrolling (which changes
+        // layoutInfo every frame) only re-triggers this button when the item COUNT actually changes.
+        val scrollTotal by remember(listState) {
+            derivedStateOf { listState.layoutInfo.totalItemsCount }
+        }
         ScrollToEdgeButton(
             listState = listState,
-            totalItems = listState.layoutInfo.totalItemsCount,
+            totalItems = scrollTotal,
             bottomBarClearance = extraBottomPadding,
         )
     }

--- a/composeApp/src/commonTest/kotlin/ktx/DoubleKtxTest.kt
+++ b/composeApp/src/commonTest/kotlin/ktx/DoubleKtxTest.kt
@@ -1,0 +1,49 @@
+package ktx
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * Parity tests for [groupThousands], the single-pass thousands-grouping helper that replaced the
+ * `toString().reversed().chunked(3).joinToString(",").reversed()` idiom on the price-formatting hot
+ * path. The new version must produce byte-identical output to the old one for every non-negative Long.
+ */
+class DoubleKtxTest {
+
+    /** The exact grouping idiom this function replaced — the source of truth for parity. */
+    private fun reference(value: Long): String =
+        value.toString().reversed().chunked(3).joinToString(",").reversed()
+
+    @Test
+    fun groupThousands_matchesReferenceAtBoundaries() {
+        val cases = listOf(
+            0L, 1L, 12L, 123L, 999L, 1_000L, 1_001L, 1_234L, 9_999L,
+            10_000L, 12_345L, 100_000L, 123_456L, 999_999L,
+            1_000_000L, 1_234_567L, 12_345_678L, 123_456_789L,
+            1_000_000_000L, 9_876_543_210L, Long.MAX_VALUE
+        )
+        for (v in cases) {
+            assertEquals(reference(v), groupThousands(v), "grouping mismatch for $v")
+        }
+    }
+
+    @Test
+    fun groupThousands_matchesReferenceAcrossRanges() {
+        // Sweep contiguous windows that straddle the 3-/6-/7-digit grouping boundaries.
+        val windows = listOf(0L..2_100L, 998_000L..1_002_000L)
+        for (window in windows) {
+            for (v in window) {
+                assertEquals(reference(v), groupThousands(v))
+            }
+        }
+    }
+
+    @Test
+    fun groupThousands_neverEmitsLeadingSeparator() {
+        // Regression guard: a digit count that is an exact multiple of 3 must not start with ','.
+        for (v in listOf(100L, 123L, 100_000L, 123_456L, 100_000_000L)) {
+            assertFalse(groupThousands(v).startsWith(","), "unexpected leading separator for $v")
+        }
+    }
+}


### PR DESCRIPTION
## Description
Real-time surfaces — the market list, order book, and portfolio — were doing far more work per ticker frame than the visible UI needs, and some of it ran on the main thread. A multi-agent performance audit (with adversarial verification) plus direct review surfaced systemic per-tick main-thread execution, per-row animation churn, and whole-universe allocation. This PR removes those without dropping any user-facing capability — the per-tick price *crossfade* is replaced by a cheaper *color flash*.

Verified locally: `compileKotlinIosSimulatorArm64` ✅ and `:composeApp:desktopTest` ✅ (22 Portfolio tests).

## Changes Made
**Engine — `ui/CryptoViewModel.kt`**
- Drain ticker frames through a single conflated `Channel` consumer instead of launching a coroutine per frame (fixes a read-modify-write race that could drop writes; removes the manual 250 ms throttle — conflation provides backpressure).
- Maintain sparkline history only for symbols the UI actually charts (visible/seeded), not the whole ~1,400-symbol universe every tick — the dominant allocation source.
- Move the market-wide filter/sort off the main thread with `flowOn(Dispatchers.Default)` on `filteredTickerDataMap` / `favoritesTickerDataMap`; prune the trades map off Main.

**Compose recomposition / animation**
- `ui/CryptoListScreen.kt`: wrap the screen-level `derivedStateOf` blocks in `remember` (market + favorites); replace per-row `AnimatedContent` + `animateContentSize` on price/percent/volume with a plain `Text` + a single `animateColorAsState` price flash; move the favorites leading spacer into its own `item()` (drops an O(n²) `indexOf`).
- `ui/OrderBookHeatMap.kt`: animate depth bars via `graphicsLayer { scaleX }` instead of `fillMaxWidth(fraction)` so the spring stays off the measure/layout pass; drop the per-row `derivedStateOf`.
- `ui/PortfolioScreen.kt` / `ui/CoinDetailScreen.kt`: gate `listState.layoutInfo.totalItemsCount` behind `derivedStateOf` so scrolling doesn't recompose the whole screen; `remember` the portfolio allocation slices.
- `ui/CoinDetailScreen.kt`: stable `key = { it.link }` on the news list.

**Models / utils**
- `model/OrderBook.kt`: `OrderBookData` equality ignores `timestamp` / `lastUpdateId` so identical books conflate at the StateFlow (neither field is read by the UI).
- `ktx/DoubleKtx.kt` / `ktx/StringKtx.kt`: single-pass thousands grouping, replacing `reversed().chunked(3).joinToString(",").reversed()`.

**Build**
- `composeApp/build.gradle.kts`: drop the now-redundant `-XXLanguage:+ExplicitBackingFields` / `-Xexplicit-backing-fields` flags (explicit backing fields are default-on at Kotlin 2.4).

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation update
- [x] Performance improvement

## Testing Done
- [ ] Unit tests added/updated — no new tests (perf-only, behavior preserved); existing suite green
- [ ] Manual testing on Android — **pending** (recommended: scroll the market list under live ticks, watch order-book bars, leave streaming a few min to confirm flat memory/CPU)
- [ ] Manual testing on iOS
- [ ] Manual testing on Desktop
- [x] Local `compileKotlinIosSimulatorArm64` ✅ and `:composeApp:desktopTest` ✅ 22/22

## Checklist
- [x] Code follows project style guidelines
- [x] Tests pass locally
- [x] No breaking changes (one intentional UX change: per-tick price crossfade → color flash)

## Notes for reviewers
- **Deferred (follow-up):** fully isolating each visible row from the whole `trades` map read (`List<UiKline>` is unstable to Compose). Largely neutralized here because history is now bounded to visible symbols (~10 rows, ~1×/sec), so this was left out rather than rushed via a signature change.
