### PR TITLE
[FEATURE] Tag-driven versioning + DeviceInfo KMP bridge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,12 @@ on:
           - web
         default: both
       version_override:
-        description: "Version tag override (leave blank to auto-increment patch from version.properties, e.g. 0.4.2 -> v0.4.3)"
+        description: "Version tag override (leave blank to auto-increment patch from gradle.properties, e.g. 0.4.2 -> v0.4.3)"
         required: false
         type: string
         default: ""
       pre_release:
         description: "Mark as pre-release"
-        required: false
-        type: boolean
-        default: false
-      build_aab:
-        description: "Also build AAB (Android App Bundle)"
         required: false
         type: boolean
         default: false
@@ -75,13 +70,13 @@ jobs:
         run: |
           PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           PREV_VER="${PREV_TAG#v}"
-          BASE_NAME=$(grep '^versionName=' version.properties | cut -d= -f2)
+          BASE_NAME=$(grep '^app\.versionName=' gradle.properties | cut -d= -f2)
 
           if [ -n "${{ inputs.version_override }}" ]; then
             NEW_TAG="${{ inputs.version_override }}"
             NEW_NAME="${NEW_TAG#v}"
           else
-            # Floor = highest of (version.properties, latest git tag).
+            # Floor = highest of (gradle.properties, latest git tag).
             # Lets the file act as a manual jump (e.g. set to 1.0.0 for major bump)
             # while normally auto-progressing from the last released tag.
             HIGHEST=$(printf '%s\n%s\n' "${PREV_VER:-0.0.0}" "${BASE_NAME:-0.0.0}" | sort -V | tail -n1)
@@ -109,11 +104,25 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Resolved: file=${BASE_NAME:-<none>} tag=${PREV_TAG:-<none>} -> ${NEW_TAG} (code ${NEW_CODE})"
 
-      - name: Create and push tag
+      - name: Bump versions, commit to main, then tag
         run: |
+          NEW_NAME="${{ steps.version.outputs.new_name }}"
+          NEW_CODE="${{ steps.version.outputs.new_code }}"
           NEW_TAG="${{ steps.version.outputs.new_tag }}"
+
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Write the resolved version into the two materialized sources:
+          # gradle.properties (Android/Web/Desktop) and the iOS pbxproj (main app + widget).
+          bash scripts/bump-version.sh "$NEW_NAME" "$NEW_CODE"
+
+          git add gradle.properties iosApp/iosApp.xcodeproj/project.pbxproj
+          git commit -m "chore(release): bump version to $NEW_NAME ($NEW_CODE) [skip ci]"
+          # Push the bump to main so the iOS project is ready for a manual App Store release.
+          git push origin HEAD:main
+
+          # Tag the bump commit so every downstream checkout carries the unified version.
           git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
           git push origin "$NEW_TAG"
 
@@ -131,7 +140,8 @@ jobs:
             RANGE="${PREV_TAG}..HEAD"
           fi
 
-          RAW_LOG=$(git log "$RANGE" --pretty=format:"%s" --no-merges 2>/dev/null || echo "")
+          # Exclude the release-bump commit this workflow just made from its own changelog.
+          RAW_LOG=$(git log "$RANGE" --pretty=format:"%s" --no-merges 2>/dev/null | grep -vE '^chore\(release\):' || echo "")
 
           FEATS=""
           FIXES=""
@@ -263,9 +273,6 @@ jobs:
           ref: ${{ needs.prepare.outputs.new_tag }}
           fetch-depth: 1
 
-      - name: Sync version files in workspace
-        run: bash scripts/bump-version.sh "${{ needs.prepare.outputs.new_name }}" "${{ needs.prepare.outputs.new_code }}"
-
       - name: Decode keystore
         run: |
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > "${RUNNER_TEMP}/release.jks"
@@ -279,7 +286,6 @@ jobs:
         run: ./gradlew :androidApp:assembleRelease
 
       - name: Build release AAB
-        if: inputs.build_aab || inputs.deploy_play_store
         env:
           KEYSTORE_FILE: ${{ runner.temp }}/release.jks
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
@@ -301,14 +307,12 @@ jobs:
           retention-days: 30
 
       - name: Rename AAB
-        if: inputs.build_aab || inputs.deploy_play_store
         run: |
           TAG="${{ needs.prepare.outputs.new_tag }}"
           AAB=$(find androidApp/build/outputs/bundle/release -name "*.aab" | head -1)
           cp "$AAB" "${RUNNER_TEMP}/UTXO-${TAG}.aab"
 
       - name: Upload AAB artifact
-        if: inputs.build_aab || inputs.deploy_play_store
         uses: actions/upload-artifact@v7
         with:
           name: android-aab
@@ -362,9 +366,6 @@ jobs:
           ref: ${{ needs.prepare.outputs.new_tag }}
           fetch-depth: 1
 
-      - name: Sync version files in workspace
-        run: bash scripts/bump-version.sh "${{ needs.prepare.outputs.new_name }}" "${{ needs.prepare.outputs.new_code }}"
-
       - name: Build wasmJs distribution
         run: ./gradlew :composeApp:wasmJsBrowserDistribution
 
@@ -410,7 +411,7 @@ jobs:
           path: release-assets/
 
       - name: Download Android AAB
-        if: needs.build-android.result == 'success' && (inputs.build_aab || inputs.deploy_play_store)
+        if: needs.build-android.result == 'success'
         uses: actions/download-artifact@v8
         with:
           name: android-aab

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -11,10 +11,6 @@ plugins {
     alias(libs.plugins.play.publisher)
 }
 
-val versionProps = Properties().apply {
-    rootProject.file("version.properties").inputStream().use { load(it) }
-}
-
 android {
     namespace = "org.androdevlinux.utxo.app"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
@@ -23,8 +19,8 @@ android {
         applicationId = "org.androdevlinux.utxo"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = versionProps.getProperty("versionCode").toInt()
-        versionName = versionProps.getProperty("versionName")
+        versionCode = providers.gradleProperty("app.versionCode").get().toInt()
+        versionName = providers.gradleProperty("app.versionName").get()
     }
 
     val keystorePropsFile = rootProject.file("keystore.properties")

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -3,26 +3,23 @@ import org.gradle.internal.os.OperatingSystem
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import java.util.Properties
+
+val appVersionNameProvider = providers.gradleProperty("app.versionName")
 
 val generateAppVersion by tasks.registering {
-    val versionFile = rootProject.file("version.properties")
     val outputDir = layout.buildDirectory.dir("generated/source/version/commonMain/kotlin")
-    inputs.file(versionFile)
+    inputs.property("versionName", appVersionNameProvider)
     outputs.dir(outputDir)
     doLast {
-        val props = Properties().apply { versionFile.inputStream().use { load(it) } }
-        val name = props.getProperty("versionName")
-        val code = props.getProperty("versionCode").toInt()
+        val name = appVersionNameProvider.get()
         val out = outputDir.get().file("buildinfo/Version.kt").asFile
         out.parentFile.mkdirs()
         out.writeText(
             """
-            // Auto-generated from version.properties. Do not edit.
+            // Auto-generated from gradle.properties (app.versionName). Do not edit.
             package buildinfo
 
             internal const val APP_VERSION_NAME: String = "$name"
-            internal const val APP_VERSION_CODE: Int = $code
 
             """.trimIndent()
         )
@@ -182,6 +179,9 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "UTXO"
+            // Pinned intentionally — NOT the app version. jpackage rejects a major of 0 on macOS
+            // (packageDmg would fail on 0.4.x), and desktop native distribution isn't part of the
+            // release pipeline. Keep at a valid >=1.0.0 placeholder.
             packageVersion = "1.0.0"
             macOS {
                 iconFile.set(project.file("src/macosMain/resources/AppIcon.icns"))

--- a/composeApp/src/androidMain/kotlin/DeviceInfo.android.kt
+++ b/composeApp/src/androidMain/kotlin/DeviceInfo.android.kt
@@ -1,0 +1,41 @@
+import android.os.Build
+import android.provider.Settings
+import buildinfo.APP_VERSION_NAME
+import org.androdevlinux.utxo.ContextProvider
+import java.util.Locale
+import java.util.TimeZone
+
+actual class DeviceInfo {
+    // Resolved lazily so construction never races the AppInitializer that sets the Context.
+    private val context get() = ContextProvider.getContext()
+
+    actual fun getDeviceType(): String = "android"
+
+    actual fun getDeviceName(): String {
+        val manufacturer = Build.MANUFACTURER
+        val model = Build.MODEL
+        return if (model.startsWith(manufacturer, ignoreCase = true)) {
+            model.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString() }
+        } else {
+            "${manufacturer.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString() }} $model"
+        }
+    }
+
+    actual fun getDeviceModel(): String = Build.MODEL
+
+    actual fun getDeviceId(): String =
+        Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID) ?: ""
+
+    actual fun getOsVersion(): String = "Android ${Build.VERSION.RELEASE}"
+
+    actual fun getAppVersion(): String {
+        return try {
+            val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+            packageInfo.versionName ?: APP_VERSION_NAME
+        } catch (_: Exception) {
+            APP_VERSION_NAME
+        }
+    }
+
+    actual fun getTimezone(): String = TimeZone.getDefault().id
+}

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -25,6 +25,8 @@
     <string name="settings_use_dark_theme">Use dark theme</string>
     <string name="settings_about">About</string>
     <string name="settings_version">Version</string>
+    <string name="settings_device">Device</string>
+    <string name="settings_os_version">OS</string>
     <string name="settings_privacy_policy">Privacy Policy</string>
     <string name="settings_website">Website</string>
     <string name="settings_github">Github</string>

--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -417,3 +417,19 @@ expect class NetworkConnectivityObserver() {
 enum class NetworkStatus {
     Available, Unavailable
 }
+
+/**
+ * Per-device runtime info, resolved by each platform. `getAppVersion()` returns the
+ * OS-reported installed version on Android/iOS and the build-time [buildinfo.APP_VERSION_NAME]
+ * constant on Desktop/Web.
+ */
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+expect class DeviceInfo() {
+    fun getDeviceType(): String
+    fun getDeviceName(): String
+    fun getDeviceModel(): String
+    fun getOsVersion(): String
+    fun getDeviceId(): String
+    fun getAppVersion(): String
+    fun getTimezone(): String
+}

--- a/composeApp/src/commonMain/kotlin/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/SettingsScreen.kt
@@ -30,7 +30,9 @@ import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.Smartphone
 import androidx.compose.material.icons.filled.Policy
 import androidx.compose.material.icons.filled.Web
 import androidx.compose.material3.AlertDialog
@@ -84,6 +86,7 @@ import model.isValidHyperliquidAddress
 import model.shortenAddress
 import network.HlAccountCheck
 import network.HyperliquidService
+import DeviceInfo
 import openLink
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
@@ -153,7 +156,8 @@ import utxo.composeapp.generated.resources.settings_title
 import utxo.composeapp.generated.resources.settings_use_dark_theme
 import utxo.composeapp.generated.resources.settings_version
 import utxo.composeapp.generated.resources.settings_website
-import buildinfo.APP_VERSION_NAME
+import utxo.composeapp.generated.resources.settings_device
+import utxo.composeapp.generated.resources.settings_os_version
 import utxo.composeapp.generated.resources.theme_dark
 import utxo.composeapp.generated.resources.theme_light
 import utxo.composeapp.generated.resources.theme_system
@@ -168,6 +172,7 @@ fun SettingsScreen(
 ) {
     var showThemeDialog by remember { mutableStateOf(false) }
     var showRssProvidersDialog by remember { mutableStateOf(false) }
+    val deviceInfo = remember { DeviceInfo() }
     val coroutineScope = rememberCoroutineScope()
     val settings: Flow<Settings?> = store.updates
     val settingsState by settings.collectAsState(initial = Settings(appTheme = AppTheme.System))
@@ -270,7 +275,19 @@ fun SettingsScreen(
                     SettingsItem(
                         icon = Icons.Default.Info,
                         title = stringResource(Res.string.settings_version),
-                        subtitle = APP_VERSION_NAME,
+                        subtitle = deviceInfo.getAppVersion(),
+                        onClick = null
+                    )
+                    SettingsItem(
+                        icon = Icons.Default.Smartphone,
+                        title = stringResource(Res.string.settings_device),
+                        subtitle = deviceInfo.getDeviceModel(),
+                        onClick = null
+                    )
+                    SettingsItem(
+                        icon = Icons.Default.Memory,
+                        title = stringResource(Res.string.settings_os_version),
+                        subtitle = deviceInfo.getOsVersion(),
                         onClick = null
                     )
                     SettingsItem(

--- a/composeApp/src/desktopMain/kotlin/App.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/App.desktop.kt
@@ -60,6 +60,8 @@ actual class NetworkConnectivityObserver {
 
 
 actual fun getKStore(): KStore<Settings> {
+    // "1.0.0" is a fixed path anchor for the data dir, NOT the app version — changing it would
+    // relocate settings.json and wipe favorites/portfolio. Keep it constant across releases.
     val directory = AppDirsFactory.getInstance()
         .getUserDataDir("org.androdevlinux.utxo", "1.0.0", "percy-g2")
     if (File(directory).exists().not()) {

--- a/composeApp/src/desktopMain/kotlin/DeviceInfo.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/DeviceInfo.desktop.kt
@@ -1,0 +1,43 @@
+import buildinfo.APP_VERSION_NAME
+import net.harawata.appdirs.AppDirsFactory
+import java.io.File
+import java.net.InetAddress
+import java.util.TimeZone
+import java.util.UUID
+
+actual class DeviceInfo {
+
+    actual fun getDeviceType(): String = "desktop"
+
+    actual fun getDeviceName(): String =
+        runCatching { InetAddress.getLocalHost().hostName }.getOrNull()
+            ?: System.getProperty("user.name")
+            ?: "Desktop"
+
+    actual fun getDeviceModel(): String =
+        "${System.getProperty("os.name")} (${System.getProperty("os.arch")})"
+
+    actual fun getOsVersion(): String =
+        "${System.getProperty("os.name")} ${System.getProperty("os.version")}"
+
+    // Stable per-install id persisted alongside settings.json in the app data dir.
+    // The "1.0.0" segment is a fixed path anchor (matches getKStore()), NOT the app version.
+    actual fun getDeviceId(): String {
+        val dir = AppDirsFactory.getInstance()
+            .getUserDataDir("org.androdevlinux.utxo", "1.0.0", "percy-g2")
+        val idFile = File(dir, "device-id")
+        runCatching { idFile.readText().trim() }.getOrNull()
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { return it }
+        val id = UUID.randomUUID().toString()
+        runCatching {
+            idFile.parentFile?.mkdirs()
+            idFile.writeText(id)
+        }
+        return id
+    }
+
+    actual fun getAppVersion(): String = APP_VERSION_NAME
+
+    actual fun getTimezone(): String = TimeZone.getDefault().id
+}

--- a/composeApp/src/iosMain/kotlin/DeviceInfo.ios.kt
+++ b/composeApp/src/iosMain/kotlin/DeviceInfo.ios.kt
@@ -1,0 +1,25 @@
+import buildinfo.APP_VERSION_NAME
+import platform.Foundation.NSBundle
+import platform.Foundation.NSTimeZone
+import platform.Foundation.localTimeZone
+import platform.UIKit.UIDevice
+
+actual class DeviceInfo {
+
+    actual fun getDeviceType(): String = "ios"
+
+    actual fun getDeviceName(): String = UIDevice.currentDevice.name
+
+    actual fun getDeviceModel(): String = UIDevice.currentDevice.model
+
+    actual fun getDeviceId(): String =
+        UIDevice.currentDevice.identifierForVendor?.UUIDString ?: ""
+
+    actual fun getOsVersion(): String = "iOS ${UIDevice.currentDevice.systemVersion}"
+
+    actual fun getAppVersion(): String =
+        NSBundle.mainBundle.objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
+            ?: APP_VERSION_NAME
+
+    actual fun getTimezone(): String = NSTimeZone.localTimeZone.name
+}

--- a/composeApp/src/wasmJsMain/kotlin/DeviceInfo.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/DeviceInfo.wasmJs.kt
@@ -1,0 +1,35 @@
+@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class)
+
+import buildinfo.APP_VERSION_NAME
+import kotlinx.browser.localStorage
+import kotlinx.browser.window
+
+actual class DeviceInfo {
+
+    actual fun getDeviceType(): String = "web"
+
+    actual fun getDeviceName(): String = window.navigator.userAgent
+
+    actual fun getDeviceModel(): String = jsNavigatorPlatform()
+
+    actual fun getOsVersion(): String = jsNavigatorPlatform()
+
+    actual fun getDeviceId(): String {
+        val existing = localStorage.getItem("device_id")
+        if (!existing.isNullOrEmpty()) return existing
+        val id = jsRandomUuid()
+        localStorage.setItem("device_id", id)
+        return id
+    }
+
+    actual fun getAppVersion(): String = APP_VERSION_NAME
+
+    actual fun getTimezone(): String = jsTimezone()
+}
+
+private fun jsNavigatorPlatform(): String = js("navigator.platform")
+
+private fun jsTimezone(): String = js("Intl.DateTimeFormat().resolvedOptions().timeZone")
+
+private fun jsRandomUuid(): String =
+    js("(self.crypto && self.crypto.randomUUID) ? self.crypto.randomUUID() : (Date.now().toString(36) + Math.random().toString(36).slice(2))")

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,8 @@ android.useAndroidX=true
 #Kotlin Multiplatform
 kotlin.mpp.enableCInteropCommonization=true
 kotlin.native.binary.smallBinary=true
+
+#App version — single source of truth for Android/Web/Desktop.
+#Bumped by CI (scripts/bump-version.sh) from the release tag; the iOS pbxproj is kept in lockstep.
+app.versionName=0.4.10
+app.versionCode=410

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -11,14 +11,16 @@ NEW_NAME="$1"
 NEW_CODE="$2"
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-PROPS="$ROOT/version.properties"
+GRADLE_PROPS="$ROOT/gradle.properties"
 PBXPROJ="$ROOT/iosApp/iosApp.xcodeproj/project.pbxproj"
 
-cat > "$PROPS" <<EOF
-versionName=$NEW_NAME
-versionCode=$NEW_CODE
-EOF
+# Android / Web / Desktop version lives in gradle.properties.
+sed -i.bak -E "s/^app\.versionName=.*/app.versionName=${NEW_NAME}/" "$GRADLE_PROPS"
+sed -i.bak -E "s/^app\.versionCode=.*/app.versionCode=${NEW_CODE}/" "$GRADLE_PROPS"
+rm -f "${GRADLE_PROPS}.bak"
 
+# iOS version lives in the Xcode project. The /g flag updates BOTH targets (main app + widget),
+# keeping the widget in lockstep so it can't drift below the host app.
 sed -i.bak -E "s/(MARKETING_VERSION = )[0-9]+(\.[0-9]+)+;/\1${NEW_NAME};/g" "$PBXPROJ"
 sed -i.bak -E "s/(CURRENT_PROJECT_VERSION = )[0-9]+;/\1${NEW_CODE};/g" "$PBXPROJ"
 rm -f "${PBXPROJ}.bak"

--- a/version.properties
+++ b/version.properties
@@ -1,2 +1,0 @@
-versionName=0.4.10
-versionCode=410


### PR DESCRIPTION
## Description

Streamlines version management so the **git release tag is the single source of truth**, and adds a **`DeviceInfo` KMP bridge** so Settings shows real per-device runtime info (version / device / OS) instead of a build-time constant.

On release, CI derives the version from the tag, writes it into the two materialized sources (`gradle.properties` + iOS `pbxproj`), commits that to `main`, tags the bump, and builds a signed APK + AAB. iOS is then released manually from Xcode at the correct version.

## Changes Made

**Versioning**
- Delete custom `version.properties`; version now lives in `gradle.properties` (`app.versionName` / `app.versionCode`), read by `androidApp/build.gradle.kts` and `composeApp`'s `generateAppVersion` task.
- `scripts/bump-version.sh` writes `gradle.properties` + the iOS `pbxproj` (both the main app **and** the widget — its `/g` sed fixes the widget's stale `0.4.2` drift).
- `.github/workflows/release.yml`: `prepare` job now bumps → commits to `main` → tags the bump commit; resolves the floor from `gradle.properties`; **always builds APK + AAB**; drops the redundant per-job sync steps and the vestigial `build_aab` input; filters the release-bump commit out of its own changelog.
- Remove the unused generated `APP_VERSION_CODE` constant.

**DeviceInfo bridge**
- `expect class DeviceInfo()` in `App.kt` with actuals for `androidMain`, `iosMain`, `desktopMain`, `wasmJsMain`.
- `getAppVersion()` returns the OS-reported version on Android/iOS and the build constant on Desktop/Web.

**Settings**
- About section shows Version + Device + OS from `DeviceInfo` (new `settings_device` / `settings_os_version` strings).

**Cleanup**
- Delete stray `err.log`; add pin-comments to the two `"1.0.0"` constants that must not track the app version (desktop `packageVersion`; AppDirs data-dir anchor).

## Type of Change
- [x] New feature
- [x] Refactoring
- [ ] Bug fix
- [ ] Documentation update
- [ ] Performance improvement

## Testing Done
- [x] Compiles on all four targets: `compileKotlinDesktop`, `compileKotlinWasmJs`, `compileKotlinIosSimulatorArm64`, `:androidApp:assembleDebug`
- [x] Manual testing on Desktop — ran the app; Settings → About shows Version `0.4.10`, Device `Mac OS X (aarch64)`, OS `Mac OS X 26.5.2` (verifies the full `gradle.properties → DeviceInfo → Settings` path)
- [x] `bump-version.sh 0.4.11 411` dry-run updated `gradle.properties` + all 4 pbxproj lines (main app + widget), then reverted
- [ ] Manual testing on iOS (bridge compiles; runtime unchanged from provided snippet)

## Checklist
- [x] Code follows project style guidelines
- [x] No breaking changes to app behavior
- [x] No secrets committed

## Notes for reviewer
- The release workflow commits the version bump to `main` as `github-actions[bot]` — an intentional, scoped exception to the repo's no-push-to-main rule (chosen during planning). If `main` has branch protection requiring PRs, `github-actions[bot]` must be allowed to push or that step will fail.
