### PR TITLE
[FEATURE] AI Insights: per-coin overview from market data and news

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -198,4 +198,19 @@
     <string name="portfolio_alloc_bar">Bar chart</string>
     <string name="portfolio_alloc_donut">Donut chart</string>
     <string name="portfolio_total">Total</string>
+
+    <!-- AI Insights -->
+    <string name="ai_insights">AI Insights</string>
+    <string name="ai_insights_loading">Analyzing market data and news…</string>
+    <string name="ai_insights_disclaimer">AI-generated overview from 24h data and news — not financial advice.</string>
+    <string name="ai_insights_error">Couldn\'t generate insights right now.</string>
+    <string name="ai_insights_retry">Retry</string>
+    <string name="ai_insights_no_key">Add a free Pollinations API key in Settings to enable AI insights.</string>
+    <string name="ai_show_key">Show key</string>
+    <string name="ai_hide_key">Hide key</string>
+    <string name="settings_ai">AI Insights</string>
+    <string name="settings_ai_desc">Generate a short market overview for each coin using a free, open-source AI (Pollinations).</string>
+    <string name="settings_ai_api_key_label">Pollinations API key</string>
+    <string name="settings_ai_api_key_hint">Paste your free key</string>
+    <string name="settings_ai_get_key">Get a free API key</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/model/AiInsight.kt
+++ b/composeApp/src/commonMain/kotlin/model/AiInsight.kt
@@ -1,0 +1,38 @@
+package model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * OpenAI-compatible chat DTOs used to talk to Pollinations' text endpoint
+ * (`POST https://text.pollinations.ai/openai`).
+ *
+ * The shapes are the standard OpenAI chat-completions contract, so the AI
+ * provider can be swapped by editing only [network.AiInsightService.AiConfig]
+ * (e.g. point at a self-hosted Pollinations instance or any other
+ * OpenAI-compatible gateway) without touching these models.
+ */
+@Serializable
+data class ChatMessage(
+    @SerialName("role") val role: String,
+    @SerialName("content") val content: String
+)
+
+@Serializable
+data class ChatCompletionRequest(
+    @SerialName("model") val model: String,
+    @SerialName("messages") val messages: List<ChatMessage>,
+    @SerialName("temperature") val temperature: Double = 0.4,
+    @SerialName("max_tokens") val maxTokens: Int = 420,
+    @SerialName("stream") val stream: Boolean = false
+)
+
+@Serializable
+data class ChatCompletionResponse(
+    @SerialName("choices") val choices: List<ChatChoice> = emptyList()
+)
+
+@Serializable
+data class ChatChoice(
+    @SerialName("message") val message: ChatMessage? = null
+)

--- a/composeApp/src/commonMain/kotlin/network/AiInsightService.kt
+++ b/composeApp/src/commonMain/kotlin/network/AiInsightService.kt
@@ -1,0 +1,197 @@
+package network
+
+import createNewsHttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.coroutines.CancellationException
+import logging.AppLogger
+import model.ChatCompletionRequest
+import model.ChatCompletionResponse
+import model.ChatMessage
+import model.NewsItem
+import model.Ticker24hr
+
+/**
+ * Generates a short, human-readable overview ("AI Insights") for a coin by
+ * combining its 24-hour ticker with recent public news headlines about the
+ * coin, using a free, OpenAI-compatible text model.
+ *
+ * Backend: **Pollinations AI** (https://pollinations.ai) — an open-source (MIT),
+ * self-hostable generative-AI gateway listed under zebbern/no-cost-ai. The
+ * request/response contract is the standard OpenAI chat-completions shape, so
+ * swapping the provider (a self-hosted Pollinations instance, llm7.io, or any
+ * other OpenAI-compatible endpoint) only requires editing [AiConfig].
+ *
+ * Privacy: only public data (price/24h stats and public news headlines) is ever
+ * sent — never wallet addresses, holdings or any personal data. Requests are tagged
+ * `private=true` so prompts stay out of Pollinations' public feed. Note that,
+ * as with any free hosted endpoint, the operator can still log requests; this
+ * is why the API key is user-supplied (Settings) rather than embedded.
+ */
+class AiInsightService {
+    private val httpClient = createNewsHttpClient()
+
+    object AiConfig {
+        /** OpenAI-compatible chat-completions endpoint. */
+        const val ENDPOINT = "https://text.pollinations.ai/openai"
+
+        /** Model id understood by the gateway ("openai" maps to a GPT-class model on Pollinations). */
+        const val MODEL = "openai"
+    }
+
+    sealed interface InsightResult {
+        data class Success(val text: String) : InsightResult
+
+        /** The endpoint requires a (free) API key or the account's budget is exhausted. */
+        data object AuthRequired : InsightResult
+
+        data class Failure(val message: String) : InsightResult
+    }
+
+    suspend fun generateInsight(
+        symbol: String,
+        baseAsset: String,
+        ticker: Ticker24hr,
+        news: List<NewsItem>,
+        apiKey: String
+    ): InsightResult {
+        return try {
+            val response: HttpResponse = httpClient.post(AiConfig.ENDPOINT) {
+                // Keep prompts out of Pollinations' public feed (ignored by other gateways).
+                parameter("private", "true")
+                contentType(ContentType.Application.Json)
+                if (apiKey.isNotBlank()) {
+                    header("Authorization", "Bearer $apiKey")
+                }
+                setBody(
+                    ChatCompletionRequest(
+                        model = AiConfig.MODEL,
+                        messages = listOf(
+                            ChatMessage(role = "system", content = SYSTEM_PROMPT),
+                            ChatMessage(role = "user", content = buildUserPrompt(symbol, baseAsset, ticker, news))
+                        )
+                    )
+                )
+            }
+
+            when (response.status) {
+                HttpStatusCode.OK -> {
+                    val text = response.body<ChatCompletionResponse>()
+                        .choices.firstOrNull()?.message?.content?.trim().orEmpty()
+                    if (text.isNotBlank()) {
+                        InsightResult.Success(text)
+                    } else {
+                        AppLogger.logger.w { "AiInsightService: empty completion for $symbol" }
+                        InsightResult.Failure("Empty response")
+                    }
+                }
+
+                HttpStatusCode.Unauthorized,
+                HttpStatusCode.PaymentRequired,
+                HttpStatusCode.Forbidden -> {
+                    AppLogger.logger.w { "AiInsightService: auth/budget required (${response.status}) for $symbol" }
+                    InsightResult.AuthRequired
+                }
+
+                else -> {
+                    AppLogger.logger.w {
+                        "AiInsightService: ${response.status} for $symbol: ${response.bodyAsText().take(200)}"
+                    }
+                    InsightResult.Failure("HTTP ${response.status.value}")
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: HttpRequestTimeoutException) {
+            AppLogger.logger.w(throwable = e) { "AiInsightService: timeout for $symbol" }
+            InsightResult.Failure("Request timed out")
+        } catch (e: Exception) {
+            AppLogger.logger.e(throwable = e) { "AiInsightService: error generating insight for $symbol" }
+            InsightResult.Failure(e.message ?: "Unknown error")
+        }
+    }
+
+    fun close() {
+        httpClient.close()
+    }
+
+    companion object {
+        /** Cap the number of headlines sent to the model to keep the prompt small. */
+        const val MAX_NEWS_ITEMS = 10
+
+        /** Trim each headline's description to bound token usage. */
+        const val MAX_SNIPPET_CHARS = 160
+
+        /**
+         * Builds the user message: 24h market data plus, when available, a compact list of
+         * the coin's most recent news headlines. Pure (no I/O) so it is directly unit-tested.
+         */
+        internal fun buildUserPrompt(
+            symbol: String,
+            baseAsset: String,
+            ticker: Ticker24hr,
+            news: List<NewsItem>
+        ): String {
+            val changePct = ticker.priceChangePercent.toDoubleOrNull() ?: 0.0
+            val direction = when {
+                changePct > 0 -> "up"
+                changePct < 0 -> "down"
+                else -> "flat"
+            }
+            val recentNews = news.take(MAX_NEWS_ITEMS)
+            return buildString {
+                if (recentNews.isEmpty()) {
+                    appendLine("Give a brief overview for the $baseAsset pair $symbol using ONLY the 24h market data below (no recent news is available).")
+                } else {
+                    appendLine("Give a brief overview for the $baseAsset pair $symbol by combining the 24h market data and the recent news headlines below.")
+                }
+                appendLine()
+                appendLine("24h MARKET DATA")
+                appendLine("Last price: ${ticker.lastPrice}")
+                appendLine("24h change: ${ticker.priceChangePercent}% ($direction)")
+                appendLine("24h high: ${ticker.highPrice}")
+                appendLine("24h low: ${ticker.lowPrice}")
+                appendLine("24h open: ${ticker.openPrice}")
+                appendLine("24h base volume: ${ticker.volume} $baseAsset")
+                appendLine("24h quote volume: ${ticker.quoteVolume}")
+                appendLine("Weighted average price: ${ticker.weightedAvgPrice}")
+
+                if (recentNews.isNotEmpty()) {
+                    appendLine()
+                    appendLine("RECENT NEWS (newest first)")
+                    recentNews.forEach { item ->
+                        val headline = item.title.collapseWhitespace()
+                        val snippet = item.description.collapseWhitespace().take(MAX_SNIPPET_CHARS)
+                        append("- [${item.source}] $headline")
+                        if (snippet.isNotBlank()) {
+                            append(" — $snippet")
+                        }
+                        appendLine()
+                    }
+                }
+            }
+        }
+
+        private fun String.collapseWhitespace(): String =
+            replace(Regex("\\s+"), " ").trim()
+
+        const val SYSTEM_PROMPT =
+            "You are a concise crypto market assistant embedded in a price-tracker app. " +
+                "You are given 24-hour ticker data for a single trading pair and, when available, a list of recent news headlines about the coin. " +
+                "Write a neutral, factual overview in 4 to 5 short sentences that combines both. " +
+                "Cover momentum and volatility (where the last price sits between the 24h high and low) and what the volume suggests about activity, " +
+                "then summarise the dominant themes or sentiment in the news and any notable catalysts. " +
+                "If no news is provided, base the overview on the market data alone and do not invent news. " +
+                "Do NOT give buy, sell or hold recommendations, price predictions, or financial advice. " +
+                "Use plain sentences only, no markdown headings or bullet lists, and keep it under 120 words."
+    }
+}

--- a/composeApp/src/commonMain/kotlin/ui/CoinDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/CoinDetailScreen.kt
@@ -24,11 +24,13 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Article
 import androidx.compose.material.icons.automirrored.filled.ShowChart
+import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
@@ -36,6 +38,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
@@ -79,6 +82,12 @@ import ui.utils.getPriceChangeColor
 import ui.utils.isDarkTheme
 import ui.utils.shimmerEffect
 import utxo.composeapp.generated.resources.Res
+import utxo.composeapp.generated.resources.ai_insights
+import utxo.composeapp.generated.resources.ai_insights_disclaimer
+import utxo.composeapp.generated.resources.ai_insights_error
+import utxo.composeapp.generated.resources.ai_insights_loading
+import utxo.composeapp.generated.resources.ai_insights_no_key
+import utxo.composeapp.generated.resources.ai_insights_retry
 import utxo.composeapp.generated.resources.back
 import utxo.composeapp.generated.resources.error
 import utxo.composeapp.generated.resources.label_24h_change
@@ -105,6 +114,7 @@ import utxo.composeapp.generated.resources.no_news_providers_selected_hint
 import utxo.composeapp.generated.resources.price_data_not_available
 import utxo.composeapp.generated.resources.price_information
 import utxo.composeapp.generated.resources.refresh
+import utxo.composeapp.generated.resources.settings_ai_get_key
 import utxo.composeapp.generated.resources.unknown_error
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -152,6 +162,10 @@ fun CoinDetailScreen(
     // Get enabled providers from settings - allow empty set (no providers selected)
     // If settings don't have enabledRssProviders field (old settings), default to all enabled
     val enabledProviders = settingsState?.enabledRssProviders ?: model.RssProvider.DEFAULT_ENABLED_PROVIDERS
+
+    // Free Pollinations key that powers AI Insights (empty = anonymous attempt / disabled).
+    val aiApiKey = settingsState?.aiApiKey ?: ""
+    val aiKeyPresent = aiApiKey.isNotBlank()
     
     // Convert Set to a stable, sorted string key for LaunchedEffect dependency
     // Use "empty" as key when no providers are selected
@@ -165,8 +179,8 @@ fun CoinDetailScreen(
     val listState = rememberLazyListState()
     val selectedTimeframe = state.selectedTimeframe
 
-    // Reload when symbol or enabled providers change
-    LaunchedEffect(symbol, enabledProvidersKey) {
+    // Reload when symbol, enabled providers, or the presence of an AI key changes
+    LaunchedEffect(symbol, enabledProvidersKey, aiKeyPresent) {
         AppLogger.logger.d { "CoinDetailScreen: LaunchedEffect triggered - symbol: $symbol, providers: $enabledProviders, key: $enabledProvidersKey" }
         // Always clear cache first to ensure we fetch fresh data with correct providers
         coroutineScope.launch {
@@ -175,7 +189,7 @@ fun CoinDetailScreen(
         // Use a local copy to ensure we're using the correct providers
         val providersToUse = enabledProviders.toSet()
         AppLogger.logger.d { "CoinDetailScreen: About to call loadCoinData with providers: $providersToUse" }
-        viewModel.loadCoinData(symbol, providersToUse)
+        viewModel.loadCoinData(symbol, providersToUse, aiApiKey)
     }
     
     // Clean up WebSocket when screen leaves composition
@@ -215,7 +229,7 @@ fun CoinDetailScreen(
                 actions = {
                     IconButton(onClick = {
                         AppLogger.logger.d { "CoinDetailScreen: Manual refresh for $symbol with providers: $enabledProviders" }
-                        viewModel.refresh(symbol, enabledProviders)
+                        viewModel.refresh(symbol, enabledProviders, aiApiKey)
                     }) {
                         Icon(
                             imageVector = Icons.Default.Refresh,
@@ -304,6 +318,19 @@ fun CoinDetailScreen(
                                         tradingPairs = tradingPairs
                                     )
                                 }
+                            }
+
+                            // AI Insights Section - market overview generated from 24h ticker data
+                            item {
+                                AiInsightCard(
+                                    insight = state.aiInsight,
+                                    isLoading = state.isLoadingInsight,
+                                    needsKey = state.insightNeedsKey,
+                                    error = state.insightError,
+                                    hasTicker = state.ticker != null,
+                                    onRetry = { viewModel.regenerateInsight() },
+                                    onGetKey = { openLink("https://enter.pollinations.ai") }
+                                )
                             }
 
                             // Order Book Heat Map Section
@@ -452,6 +479,125 @@ fun CoinDetailScreen(
 
 }
 
+
+@Composable
+fun AiInsightCard(
+    insight: String?,
+    isLoading: Boolean,
+    needsKey: Boolean,
+    error: String?,
+    hasTicker: Boolean,
+    onRetry: () -> Unit,
+    onGetKey: () -> Unit
+) {
+    // Treat the pre-ticker window as loading so the card never shows an empty body.
+    val showLoading = isLoading || (!hasTicker && error == null && !needsKey && insight == null)
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .animateContentSize()
+                .padding(16.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.AutoAwesome,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = stringResource(Res.string.ai_insights),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+                if (!showLoading && (insight != null || error != null)) {
+                    IconButton(onClick = onRetry, modifier = Modifier.size(32.dp)) {
+                        Icon(
+                            imageVector = Icons.Default.Refresh,
+                            contentDescription = stringResource(Res.string.ai_insights_retry),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            when {
+                needsKey -> {
+                    Text(
+                        text = stringResource(Res.string.ai_insights_no_key),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    TextButton(
+                        onClick = onGetKey,
+                        modifier = Modifier.padding(top = 4.dp)
+                    ) {
+                        Text(stringResource(Res.string.settings_ai_get_key))
+                    }
+                }
+
+                showLoading -> {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(18.dp),
+                            strokeWidth = 2.dp
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Text(
+                            text = stringResource(Res.string.ai_insights_loading),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+
+                error != null -> {
+                    Text(
+                        text = stringResource(Res.string.ai_insights_error),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                    TextButton(
+                        onClick = onRetry,
+                        modifier = Modifier.padding(top = 4.dp)
+                    ) {
+                        Text(stringResource(Res.string.ai_insights_retry))
+                    }
+                }
+
+                insight != null -> {
+                    Text(
+                        text = insight,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Text(
+                        text = stringResource(Res.string.ai_insights_disclaimer),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f)
+                    )
+                }
+            }
+        }
+    }
+}
 
 @Composable
 fun PriceInfoSection(

--- a/composeApp/src/commonMain/kotlin/ui/CoinDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/ui/CoinDetailViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -15,6 +16,7 @@ import model.NewsItem
 import model.OrderBookData
 import model.RssProvider
 import model.Ticker24hr
+import network.AiInsightService
 import network.NewsService
 import network.OrderBookWebSocketService
 import network.TickerWebSocketService
@@ -33,7 +35,11 @@ data class CoinDetailState(
     val orderBookData: OrderBookData? = null,
     val orderBookError: String? = null,
     val error: String? = null,
-    val selectedTimeframe: String = "1m"
+    val selectedTimeframe: String = "1m",
+    val isLoadingInsight: Boolean = false,
+    val aiInsight: String? = null,
+    val insightError: String? = null,
+    val insightNeedsKey: Boolean = false
 )
 
 @OptIn(ExperimentalTime::class)
@@ -42,13 +48,16 @@ class CoinDetailViewModel : ViewModel() {
     private val newsService = NewsService()
     private val orderBookService = OrderBookWebSocketService()
     private val tickerWebSocketService = TickerWebSocketService()
+    private val aiInsightService = AiInsightService()
 
     val state: StateFlow<CoinDetailState>
         field = MutableStateFlow(CoinDetailState())
 
     private var currentLoadJob: Job? = null
     private var timeframeChangeJob: Job? = null
+    private var insightJob: Job? = null
     private var currentSymbol: String? = null
+    private var currentApiKey: String = ""
 
     private val newsUpdateMutex = Mutex()
 
@@ -85,10 +94,16 @@ class CoinDetailViewModel : ViewModel() {
         }
     }
 
-    fun loadCoinData(symbol: String, enabledRssProviders: Set<String> = RssProvider.DEFAULT_ENABLED_PROVIDERS) {
+    fun loadCoinData(
+        symbol: String,
+        enabledRssProviders: Set<String> = RssProvider.DEFAULT_ENABLED_PROVIDERS,
+        aiApiKey: String = ""
+    ) {
         currentLoadJob?.cancel()
+        insightJob?.cancel()
 
         currentSymbol = symbol
+        currentApiKey = aiApiKey
         val timeframe = state.value.selectedTimeframe
 
         orderBookService.connect(symbol, levels = 20)
@@ -106,110 +121,190 @@ class CoinDetailViewModel : ViewModel() {
                 orderBookData = null,
                 orderBookError = null,
                 error = null,
-                selectedTimeframe = timeframe
+                selectedTimeframe = timeframe,
+                // Keep the insight card in its loading state until both the ticker and the
+                // news have been gathered and the combined insight has been generated.
+                isLoadingInsight = true
             )
 
-            launch {
-                try {
-                    val ticker = httpClient.fetchTicker24hr(symbol)
-                    state.update {
-                        it.copy(
-                            ticker = ticker,
-                            isLoadingTicker = false
-                        )
-                    }
-                    if (ticker == null) {
-                        AppLogger.logger.w { "CoinDetailViewModel: Failed to fetch ticker for symbol: $symbol" }
-                    }
-                } catch (e: kotlinx.coroutines.CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    AppLogger.logger.e(throwable = e) { "CoinDetailViewModel: Error loading ticker for $symbol" }
-                    state.update { it.copy(isLoadingTicker = false) }
-                }
-            }
+            // Fetch the ticker and news concurrently, then generate a single insight that
+            // combines the 24h market data with the coin's recent news.
+            val tickerDeferred = async { loadTicker(symbol) }
+            val newsDeferred = async { loadNews(symbol, enabledRssProviders) }
 
-            if (enabledRssProviders.isNotEmpty()) {
-                launch {
-                    try {
-                        val providersToLoad = enabledRssProviders.toSet()
+            val ticker = tickerDeferred.await()
+            val news = newsDeferred.await()
 
-                        val providerJobs = RssProvider.ALL_PROVIDERS
-                            .filter { providersToLoad.contains(it.id) }
-                            .map { provider ->
-                                async {
-                                    try {
-                                        val news = newsService.fetchNewsFromProvider(provider, symbol)
-
-                                        val isFailure = news.isEmpty()
-
-                                        updateNewsState { currentState ->
-                                            val updatedNews = if (news.isNotEmpty()) {
-                                                (currentState.news + news)
-                                                    .distinctBy { it.link }
-                                                    .sortedByDescending { item ->
-                                                        try {
-                                                            ktx.parseRssDate(item.pubDate)
-                                                        } catch (_: Exception) {
-                                                            kotlin.time.Instant.fromEpochMilliseconds(0)
-                                                        }
-                                                    }
-                                                    .take(50)
-                                            } else {
-                                                currentState.news
-                                            }
-
-                                            currentState.copy(
-                                                news = updatedNews,
-                                                loadingNewsProviders = currentState.loadingNewsProviders - provider.id
-                                            )
-                                        }
-
-                                        if (isFailure) {
-                                            AppLogger.logger.w { "CoinDetailViewModel: Provider ${provider.name} returned no news items" }
-                                        }
-
-                                        news
-                                    } catch (e: Exception) {
-                                        AppLogger.logger.e(throwable = e) { "CoinDetailViewModel: Error loading news from ${provider.name}" }
-                                        updateNewsState { currentState ->
-                                            currentState.copy(
-                                                loadingNewsProviders = currentState.loadingNewsProviders - provider.id
-                                            )
-                                        }
-                                        emptyList()
-                                    }
-                                }
-                            }
-
-                        providerJobs.awaitAll()
-
-                        state.update { it.copy(isLoadingNews = false) }
-
-                        AppLogger.logger.i { "CoinDetailViewModel: Finished loading news - ${state.value.news.size} items" }
-                    } catch (e: kotlinx.coroutines.CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        AppLogger.logger.e(throwable = e) { "CoinDetailViewModel: Error loading news for $symbol" }
-                        state.update {
-                            it.copy(
-                                isLoadingNews = false,
-                                loadingNewsProviders = emptySet()
-                            )
-                        }
-                    }
-                }
+            if (ticker != null) {
+                generateInsightFor(symbol, ticker, news, currentApiKey)
             } else {
-                state.update { it.copy(isLoadingNews = false, loadingNewsProviders = emptySet()) }
+                state.update { it.copy(isLoadingInsight = false) }
             }
         }
     }
 
-    fun refresh(symbol: String, enabledRssProviders: Set<String> = RssProvider.DEFAULT_ENABLED_PROVIDERS) {
+    /** Fetches the 24h ticker, updates state, and returns it (or null on failure). */
+    private suspend fun loadTicker(symbol: String): Ticker24hr? {
+        return try {
+            val ticker = httpClient.fetchTicker24hr(symbol)
+            state.update { it.copy(ticker = ticker, isLoadingTicker = false) }
+            if (ticker == null) {
+                AppLogger.logger.w { "CoinDetailViewModel: Failed to fetch ticker for symbol: $symbol" }
+            }
+            ticker
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            AppLogger.logger.e(throwable = e) { "CoinDetailViewModel: Error loading ticker for $symbol" }
+            state.update { it.copy(isLoadingTicker = false) }
+            null
+        }
+    }
+
+    /**
+     * Loads news from every enabled provider in parallel, updating state incrementally as
+     * each provider returns, and returns the final combined/deduped news list.
+     */
+    private suspend fun loadNews(symbol: String, enabledRssProviders: Set<String>): List<NewsItem> {
+        if (enabledRssProviders.isEmpty()) {
+            state.update { it.copy(isLoadingNews = false, loadingNewsProviders = emptySet()) }
+            return emptyList()
+        }
+        return try {
+            val providersToLoad = enabledRssProviders.toSet()
+
+            coroutineScope {
+                RssProvider.ALL_PROVIDERS
+                    .filter { providersToLoad.contains(it.id) }
+                    .map { provider ->
+                        async {
+                            try {
+                                val news = newsService.fetchNewsFromProvider(provider, symbol)
+
+                                val isFailure = news.isEmpty()
+
+                                updateNewsState { currentState ->
+                                    val updatedNews = if (news.isNotEmpty()) {
+                                        (currentState.news + news)
+                                            .distinctBy { it.link }
+                                            .sortedByDescending { item ->
+                                                try {
+                                                    ktx.parseRssDate(item.pubDate)
+                                                } catch (_: Exception) {
+                                                    kotlin.time.Instant.fromEpochMilliseconds(0)
+                                                }
+                                            }
+                                            .take(50)
+                                    } else {
+                                        currentState.news
+                                    }
+
+                                    currentState.copy(
+                                        news = updatedNews,
+                                        loadingNewsProviders = currentState.loadingNewsProviders - provider.id
+                                    )
+                                }
+
+                                if (isFailure) {
+                                    AppLogger.logger.w { "CoinDetailViewModel: Provider ${provider.name} returned no news items" }
+                                }
+
+                                news
+                            } catch (e: Exception) {
+                                AppLogger.logger.e(throwable = e) { "CoinDetailViewModel: Error loading news from ${provider.name}" }
+                                updateNewsState { currentState ->
+                                    currentState.copy(
+                                        loadingNewsProviders = currentState.loadingNewsProviders - provider.id
+                                    )
+                                }
+                                emptyList()
+                            }
+                        }
+                    }
+                    .awaitAll()
+            }
+
+            state.update { it.copy(isLoadingNews = false) }
+
+            AppLogger.logger.i { "CoinDetailViewModel: Finished loading news - ${state.value.news.size} items" }
+
+            state.value.news
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            AppLogger.logger.e(throwable = e) { "CoinDetailViewModel: Error loading news for $symbol" }
+            state.update {
+                it.copy(
+                    isLoadingNews = false,
+                    loadingNewsProviders = emptySet()
+                )
+            }
+            emptyList()
+        }
+    }
+
+    fun refresh(
+        symbol: String,
+        enabledRssProviders: Set<String> = RssProvider.DEFAULT_ENABLED_PROVIDERS,
+        aiApiKey: String = currentApiKey
+    ) {
         viewModelScope.launch {
             newsService.clearCache()
-            loadCoinData(symbol, enabledRssProviders)
+            loadCoinData(symbol, enabledRssProviders, aiApiKey)
         }
+    }
+
+    /**
+     * Regenerates the AI insight for the current coin using the already-fetched ticker and
+     * the news currently shown on screen.
+     */
+    fun regenerateInsight() {
+        val symbol = currentSymbol ?: return
+        val ticker = state.value.ticker ?: return
+        generateInsightFor(symbol, ticker, state.value.news, currentApiKey)
+    }
+
+    private fun generateInsightFor(symbol: String, ticker: Ticker24hr, news: List<NewsItem>, apiKey: String) {
+        insightJob?.cancel()
+        insightJob = viewModelScope.launch {
+            state.update {
+                it.copy(isLoadingInsight = true, insightError = null, insightNeedsKey = false)
+            }
+            val baseAsset = extractBaseAsset(symbol)
+            when (val result = aiInsightService.generateInsight(symbol, baseAsset, ticker, news, apiKey)) {
+                is AiInsightService.InsightResult.Success -> state.update {
+                    it.copy(
+                        aiInsight = result.text,
+                        isLoadingInsight = false,
+                        insightError = null,
+                        insightNeedsKey = false
+                    )
+                }
+
+                is AiInsightService.InsightResult.AuthRequired -> state.update {
+                    it.copy(isLoadingInsight = false, insightNeedsKey = true, aiInsight = null)
+                }
+
+                is AiInsightService.InsightResult.Failure -> state.update {
+                    it.copy(isLoadingInsight = false, insightError = result.message)
+                }
+            }
+        }
+    }
+
+    /** Strips a common quote-currency suffix so "BTCUSDT" -> "BTC" for the prompt. */
+    private fun extractBaseAsset(symbol: String): String {
+        val quoteCurrencies = listOf(
+            "FDUSD", "BUSD", "TUSD", "USDT", "USDC", "USD1", "DAI",
+            "BTC", "ETH", "BNB", "EUR", "GBP", "JPY"
+        ).sortedByDescending { it.length }
+        val upper = symbol.uppercase()
+        for (quote in quoteCurrencies) {
+            if (upper.endsWith(quote) && upper.length > quote.length) {
+                return upper.removeSuffix(quote)
+            }
+        }
+        return upper
     }
 
     fun clearCache() {
@@ -232,9 +327,11 @@ class CoinDetailViewModel : ViewModel() {
         super.onCleared()
         timeframeChangeJob?.cancel()
         currentLoadJob?.cancel()
+        insightJob?.cancel()
         orderBookService.close()
         tickerWebSocketService.close()
         httpClient.close()
         newsService.close()
+        aiInsightService.close()
     }
 }

--- a/composeApp/src/commonMain/kotlin/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/SettingsScreen.kt
@@ -12,8 +12,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -23,6 +26,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Article
 import androidx.compose.material.icons.filled.AccountBalanceWallet
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Close
@@ -34,6 +38,8 @@ import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Smartphone
 import androidx.compose.material.icons.filled.Policy
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Web
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -66,6 +72,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -97,10 +106,17 @@ import ui.utils.bottomBarClearancePadding
 import ui.utils.debouncedClickable
 import ui.utils.isDarkTheme
 import utxo.composeapp.generated.resources.Res
+import utxo.composeapp.generated.resources.ai_hide_key
+import utxo.composeapp.generated.resources.ai_show_key
 import utxo.composeapp.generated.resources.back
 import utxo.composeapp.generated.resources.cancel
 import utxo.composeapp.generated.resources.github_icon
 import utxo.composeapp.generated.resources.settings_about
+import utxo.composeapp.generated.resources.settings_ai
+import utxo.composeapp.generated.resources.settings_ai_api_key_hint
+import utxo.composeapp.generated.resources.settings_ai_api_key_label
+import utxo.composeapp.generated.resources.settings_ai_desc
+import utxo.composeapp.generated.resources.settings_ai_get_key
 import utxo.composeapp.generated.resources.settings_all_sources_enabled
 import utxo.composeapp.generated.resources.settings_appearance
 import utxo.composeapp.generated.resources.settings_clear
@@ -264,6 +280,21 @@ fun SettingsScreen(
                 }
 
                 item {
+                    SettingsHeader(title = stringResource(Res.string.settings_ai))
+                    AiInsightsSettings(
+                        apiKey = settingsState?.aiApiKey ?: "",
+                        onApiKeyChange = { newKey ->
+                            coroutineScope.launch {
+                                store.update { current ->
+                                    current?.copy(aiApiKey = newKey) ?: Settings(aiApiKey = newKey)
+                                }
+                            }
+                        },
+                        onGetKey = { openLink("https://enter.pollinations.ai") }
+                    )
+                }
+
+                item {
                     SettingsHeader(title = stringResource(Res.string.settings_portfolio))
                     PortfolioWalletsManager(
                         wallets = settingsState?.hyperliquidWallets ?: emptyList(),
@@ -346,6 +377,73 @@ private fun SettingsHeader(title: String) {
         color = MaterialTheme.colorScheme.primary,
         modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
     )
+}
+
+@Composable
+private fun AiInsightsSettings(
+    apiKey: String,
+    onApiKeyChange: (String) -> Unit,
+    onGetKey: () -> Unit
+) {
+    // Seed once; this screen is the only editor, so external re-emissions won't clobber typing.
+    var keyText by remember { mutableStateOf(apiKey) }
+    var keyVisible by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = Icons.Default.AutoAwesome,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(24.dp)
+            )
+            Text(
+                text = stringResource(Res.string.settings_ai_desc),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 16.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        OutlinedTextField(
+            value = keyText,
+            onValueChange = {
+                keyText = it.trim()
+                onApiKeyChange(keyText)
+            },
+            label = { Text(stringResource(Res.string.settings_ai_api_key_label)) },
+            placeholder = { Text(stringResource(Res.string.settings_ai_api_key_hint)) },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            visualTransformation = if (keyVisible) VisualTransformation.None else PasswordVisualTransformation(),
+            trailingIcon = {
+                IconButton(onClick = { keyVisible = !keyVisible }) {
+                    Icon(
+                        imageVector = if (keyVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                        contentDescription = stringResource(
+                            if (keyVisible) Res.string.ai_hide_key else Res.string.ai_show_key
+                        )
+                    )
+                }
+            },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        TextButton(
+            onClick = onGetKey,
+            modifier = Modifier.padding(top = 4.dp)
+        ) {
+            Text(stringResource(Res.string.settings_ai_get_key))
+        }
+    }
 }
 
 @Composable
@@ -1361,6 +1459,8 @@ data class Settings(
     val hyperliquidWallets: List<HyperliquidWallet> = emptyList(),
     /** [SCOPE_ALL] (aggregate) or a single lowercased wallet address. */
     val portfolioScope: String = SCOPE_ALL,
+    /** User-supplied free Pollinations API key that powers AI Insights. Empty = disabled. */
+    val aiApiKey: String = "",
 )
 
 enum class AppTheme {

--- a/composeApp/src/commonTest/kotlin/network/AiInsightPromptTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/AiInsightPromptTest.kt
@@ -1,0 +1,101 @@
+package network
+
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import model.NewsItem
+import model.Ticker24hr
+
+/**
+ * Unit tests for [AiInsightService.buildUserPrompt] — the pure prompt builder that turns a
+ * coin's 24h ticker and recent news into the message sent to the AI. These lock in the core
+ * behaviour of this feature: news data actually reaches the model alongside the market data.
+ */
+class AiInsightPromptTest {
+
+    private fun ticker() = Ticker24hr(
+        symbol = "BTCUSDT",
+        priceChange = "1200.0",
+        priceChangePercent = "2.05",
+        weightedAvgPrice = "59000.0",
+        prevClosePrice = "58000.0",
+        lastPrice = "60000.0",
+        lastQty = "0.1",
+        bidPrice = "59999.0",
+        bidQty = "1.0",
+        askPrice = "60001.0",
+        askQty = "1.0",
+        openPrice = "58800.0",
+        highPrice = "60500.0",
+        lowPrice = "58500.0",
+        volume = "12345.0",
+        quoteVolume = "700000000.0",
+        openTime = 0L,
+        closeTime = 0L
+    )
+
+    private fun news() = listOf(
+        NewsItem(
+            title = "Bitcoin  ETF   sees record inflows",
+            description = "Spot   BTC funds\n absorbed money in a day.",
+            link = "https://example.com/a",
+            pubDate = "Wed, 16 Jul 2026 10:00:00 GMT",
+            source = "CoinDesk"
+        ),
+        NewsItem(
+            title = "Analysts eye BTC volatility",
+            description = "Options desks report elevated demand.",
+            link = "https://example.com/b",
+            pubDate = "Wed, 16 Jul 2026 09:00:00 GMT",
+            source = "The Block"
+        )
+    )
+
+    @Test
+    fun prompt_includes_both_market_data_and_news() {
+        val prompt = AiInsightService.buildUserPrompt("BTCUSDT", "BTC", ticker(), news())
+
+        // Market block is present.
+        assertContains(prompt, "24h MARKET DATA")
+        assertContains(prompt, "Last price: 60000.0")
+        assertContains(prompt, "24h change: 2.05% (up)")
+
+        // News block is present, each item labelled with its source, headline and snippet.
+        assertContains(prompt, "RECENT NEWS")
+        assertContains(prompt, "[CoinDesk] Bitcoin ETF sees record inflows") // whitespace collapsed
+        assertContains(prompt, "[The Block] Analysts eye BTC volatility")
+
+        // Newlines/extra whitespace inside descriptions are collapsed to single spaces.
+        assertFalse(prompt.contains("\n absorbed"), "description newlines should be collapsed")
+    }
+
+    @Test
+    fun prompt_falls_back_to_market_only_when_no_news() {
+        val prompt = AiInsightService.buildUserPrompt("BTCUSDT", "BTC", ticker(), emptyList())
+
+        assertContains(prompt, "no recent news is available")
+        assertContains(prompt, "24h MARKET DATA")
+        assertFalse(prompt.contains("RECENT NEWS"), "no news section when the list is empty")
+    }
+
+    @Test
+    fun prompt_caps_the_number_of_news_items() {
+        val many = (1..25).map {
+            NewsItem(
+                title = "Headline $it about BTC",
+                description = "desc $it",
+                link = "https://example.com/$it",
+                pubDate = "",
+                source = "U.Today"
+            )
+        }
+        val prompt = AiInsightService.buildUserPrompt("BTCUSDT", "BTC", ticker(), many)
+
+        // Only the first MAX_NEWS_ITEMS (10) headlines are included.
+        assertContains(prompt, "Headline ${AiInsightService.MAX_NEWS_ITEMS} about BTC")
+        assertFalse(
+            prompt.contains("Headline ${AiInsightService.MAX_NEWS_ITEMS + 1} about BTC"),
+            "news list should be capped at MAX_NEWS_ITEMS"
+        )
+    }
+}


### PR DESCRIPTION
## Description
Adds an **AI Insights** card to the coin detail screen that generates a short, neutral overview of a coin by combining its **24h market data** with the coin's **recent news from all enabled RSS providers**. The overview is produced by the free, OpenAI-compatible [Pollinations](https://pollinations.ai) text endpoint (provider is swappable via `AiConfig`). An optional user-supplied API key can be set in Settings.

Previously the insight was generated from market data alone; it now synthesizes both price action and news themes/sentiment.

## Changes Made
- **`network/AiInsightService.kt`** — OpenAI-compatible chat client. Pure `buildUserPrompt` assembles the prompt from 24h ticker data plus a capped (top 10), whitespace-collapsed, 160-char-trimmed list of recent news headlines. Falls back to a market-only prompt (with an explicit "no news" instruction so the model never invents news). Handles OK / auth-or-budget / failure / timeout.
- **`model/AiInsight.kt`** — OpenAI chat-completion request/response DTOs (`max_tokens` 420 to fit the added news synthesis).
- **`ui/CoinDetailViewModel.kt`** — fetches ticker and news concurrently (`async`), awaits both, then generates a single combined insight; the card stays in its loading state throughout so it never flashes empty between ticker-loaded and news-loaded. Retry regenerates from the news currently on screen. `CancellationException` rethrown; jobs cancelled in `onCleared()`.
- **`ui/CoinDetailScreen.kt`** — `AiInsightCard` with loading / error / no-key states and a disclaimer.
- **`ui/SettingsScreen.kt`** — user-supplied Pollinations API key.
- **`composeResources/values/strings.xml`** — AI Insights copy.
- **`commonTest/.../AiInsightPromptTest.kt`** — unit tests for the prompt builder.

## Type of Change
- [x] New feature

## Testing Done
- [x] Unit tests added — `AiInsightPromptTest` (3 tests): news + market data both present in the prompt, market-only fallback when no news, news-item cap. All pass.
- [x] iOS type-check: `./gradlew compileKotlinIosSimulatorArm64` clean.
- [x] Full desktop test suite green (`:composeApp:desktopTest`).
- [x] Manual on-device testing across platforms

## Checklist
- [x] Code follows project style guidelines (`MaterialTheme` colors, `stringResource`, coroutine conventions)
- [x] Tests pass locally
- [x] No breaking changes

## Privacy
Only public data (price/24h stats and public news headlines) is ever sent to the endpoint; requests are tagged `private=true`, and the API key is user-supplied rather than embedded.