### PR TITLE
[FIX] Stop widget deep-link from stacking coin detail screens

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         <activity
             android:exported="true"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
+            android:launchMode="singleTop"
             android:name="org.androdevlinux.utxo.MainActivity"
             android:screenOrientation="portrait"
             tools:ignore="LockedOrientationActivity">

--- a/composeApp/src/androidMain/kotlin/org/androdevlinux/utxo/widget/helper/WidgetUpdateHelper.kt
+++ b/composeApp/src/androidMain/kotlin/org/androdevlinux/utxo/widget/helper/WidgetUpdateHelper.kt
@@ -153,7 +153,12 @@ object WidgetUpdateHelper {
                             setClassName(context, "org.androdevlinux.utxo.MainActivity")
                             putExtra("coin_symbol", symbol)
                             putExtra("coin_display_symbol", displaySymbol)
-                            flags = android.content.Intent.FLAG_ACTIVITY_NEW_TASK or android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP
+                            // SINGLE_TOP pairs with MainActivity's singleTop launchMode so the tap is
+                            // delivered to the existing instance via onNewIntent instead of recreating it,
+                            // preserving the in-app back stack.
+                            flags = android.content.Intent.FLAG_ACTIVITY_NEW_TASK or
+                                android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                                android.content.Intent.FLAG_ACTIVITY_SINGLE_TOP
                         }
                         val coinDetailPendingIntent = android.app.PendingIntent.getActivity(
                             context,

--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -96,56 +96,36 @@ fun App(
     val networkStatus by networkObserver.observe().collectAsState(initial = null)
     val lifecycleOwner = LocalLifecycleOwner.current
     
-    // Helper function to get current CoinDetail route if we're on CoinDetail screen
-    fun getCurrentCoinDetailRoute(): CoinDetail? {
-        val currentEntry = navBackStackEntry ?: return null
-        val currentDestination = currentEntry.destination.id
-        if (currentDestination == CoinDetail.serializer().generateHashCode()) {
-            return try {
-                currentEntry.toRoute<CoinDetail>()
-            } catch (e: Exception) {
-                // Defensive handling: toRoute may throw various exceptions during deserialization
-                // Return null to gracefully handle any route parsing errors
-                null
-            }
-        }
-        return null
-    }
-    
-    // Helper function to navigate to CoinDetail, replacing if already on CoinDetail
+    // Navigate to CoinDetail from a widget deep-link, idempotently: a repeated or rapid tap must
+    // never stack a second CoinDetail on the back stack.
     fun navigateToCoinDetail(symbol: String, displaySymbol: String) {
-        val currentCoinDetail = getCurrentCoinDetailRoute()
-        val isAlreadyOnCoinDetail = currentCoinDetail != null
-        val isDifferentSymbol = currentCoinDetail?.symbol != symbol
-        
-        if (isAlreadyOnCoinDetail && isDifferentSymbol) {
-            // Replace current CoinDetail destination using atomic navigation
-            // We already know we're on CoinDetail from getCurrentCoinDetailRoute(), so destination ID exists
-            val currentDestinationId = navBackStackEntry?.destination?.id
-            navController.navigate(
-                CoinDetail(
-                    symbol = symbol,
-                    displaySymbol = displaySymbol
-                )
-            ) {
-                // Pop the current CoinDetail destination and replace it atomically
-                currentDestinationId?.let {
-                    popUpTo(it) { inclusive = true }
-                } ?: run {
-                    // Fallback: pop backstack if destination ID unavailable (shouldn't happen)
-                    popUpTo(navController.graph.startDestinationId) { saveState = false }
-                }
-            }
-        } else if (!isAlreadyOnCoinDetail) {
-            // Normal navigation when not on CoinDetail screen
-            navController.navigate(
-                CoinDetail(
-                    symbol = symbol,
-                    displaySymbol = displaySymbol
-                )
+        // Decide against the LIVE back stack (navController.currentBackStackEntry), not the lagging
+        // currentBackStackEntryAsState() `navBackStackEntry`. The latter updates a frame or more
+        // after navigate(), so during a transition / second tap it still reports the previous
+        // screen — which is exactly what let duplicate CoinDetail entries slip through before.
+        val liveEntry = navController.currentBackStackEntry
+        val onCoinDetail = liveEntry?.destination?.id == CoinDetail.serializer().generateHashCode()
+        // onCoinDetail == true smart-casts liveEntry to non-null. runCatching guards toRoute()
+        // against any deserialization failure (matching the previous defensive handling); a null
+        // result simply falls through to a fresh navigate below.
+        val currentSymbol =
+            if (onCoinDetail) runCatching { liveEntry.toRoute<CoinDetail>().symbol }.getOrNull()
+            else null
+
+        // Already showing this exact coin — nothing to do (avoids a needless screen reload).
+        if (onCoinDetail && currentSymbol == symbol) return
+
+        // Pop any existing CoinDetail first so deep-links can never pile up, then push exactly one.
+        // popUpTo is a no-op when no CoinDetail is on the stack.
+        navController.navigate(
+            CoinDetail(
+                symbol = symbol,
+                displaySymbol = displaySymbol
             )
+        ) {
+            popUpTo(CoinDetail.serializer().generateHashCode()) { inclusive = true }
+            launchSingleTop = true
         }
-        // If already on CoinDetail with same symbol, do nothing
     }
     
     // Handle coin detail intent from widget

--- a/iosApp/iosApp/LiquidGlassRootView.swift
+++ b/iosApp/iosApp/LiquidGlassRootView.swift
@@ -93,7 +93,10 @@ struct LiquidGlassRootView: View {
         if let coin = urlHandler.pendingCoin {
             urlHandler.pendingCoin = nil
             selection = 0
-            marketPath.append(coin)
+            // Replace any existing coin detail rather than appending, so repeated widget taps
+            // never stack multiple detail screens on the Market tab's NavigationStack. Setting an
+            // equal single-element path is a no-op, so re-tapping the same coin doesn't reload it.
+            marketPath = NavigationPath([coin])
         }
         if urlHandler.selectFavorites {
             urlHandler.selectFavorites = false

--- a/iosApp/iosApp/LiquidGlassRootView.swift
+++ b/iosApp/iosApp/LiquidGlassRootView.swift
@@ -31,7 +31,13 @@ struct LiquidGlassRootView: View {
                     .ignoresSafeArea(.container, edges: .bottom)
                     .toolbar(.hidden, for: .navigationBar)
                     .navigationDestination(for: CoinRoute.self) { route in
+                        // Tie the destination's identity to the coin so a widget deep-link that
+                        // REPLACES the path (e.g. BTC -> ETH) recreates the Compose host instead of
+                        // reusing the previous one. CoinDetailComposeView.updateUIViewController is a
+                        // no-op, so without a per-coin id the hosted ComposeUIViewController would
+                        // keep showing the old coin.
                         detail(route) { marketPath.removeLast() }
+                            .id(route)
                     }
                 }
             }
@@ -45,7 +51,9 @@ struct LiquidGlassRootView: View {
                     .ignoresSafeArea(.container, edges: .bottom)
                     .toolbar(.hidden, for: .navigationBar)
                     .navigationDestination(for: CoinRoute.self) { route in
+                        // Per-coin identity, mirroring the Market stack (see note above).
                         detail(route) { favPath.removeLast() }
+                            .id(route)
                     }
                 }
             }


### PR DESCRIPTION
## Description

Tapping a coin in the home-screen widget deep-links into the app and opens that coin's detail screen. Tapping the widget repeatedly (without pressing back in between) kept **pushing a new copy** of the coin detail screen onto the navigation back stack, so the user had to press back once per tap to escape. This affected both **Android** and **iOS**.

**Root cause:**
- **Compose / Android (and iOS <26 fallback):** the widget deep-link went through `navigateToCoinDetail`, whose "push" branch called `navController.navigate(CoinDetail(...))` with no `popUpTo`/`launchSingleTop`. The guard that decided whether to push read `currentBackStackEntryAsState()` — a Compose `State` that **lags a frame or more** behind the real back stack — so during the transition after a tap it still reported the previous screen and pushed another detail.
- **iOS 26 (native SwiftUI TabView):** `LiquidGlassRootView.consumeDeepLink()` called `marketPath.append(coin)` unconditionally, appending another `CoinRoute` to the Market tab's `NavigationStack` on every deep-link.

## Changes Made

- **`composeApp/src/commonMain/kotlin/App.kt`** — made `navigateToCoinDetail` idempotent: decide against the live `navController.currentBackStackEntry` (not the lagging collected state) and always `popUpTo(CoinDetail){ inclusive = true }` + `launchSingleTop = true`, so a widget deep-link yields exactly one detail, replacing any current one. Removed the now-dead `getCurrentCoinDetailRoute` helper.
- **`androidApp/src/main/AndroidManifest.xml`** — `MainActivity` `launchMode="singleTop"`.
- **`composeApp/.../widget/helper/WidgetUpdateHelper.kt`** — added `FLAG_ACTIVITY_SINGLE_TOP` to the per-coin widget intent, so taps reuse the running app via `onNewIntent` and preserve the in-app back stack.
- **`iosApp/iosApp/LiquidGlassRootView.swift`** — replace the Market `NavigationStack` path (`marketPath = NavigationPath([coin])`) instead of appending, so repeated deep-links never stack on iOS 26. An equal single-element path is a no-op, so re-tapping the same coin doesn't reload it.

## Type of Change
- [x] Bug fix

## Testing Done
- [x] Manual testing on Android (emulator, iPhone-equivalent flow via `adb`): fired the widget's exact deep-link Intent 4× for the same coin and 3× across different coins (BTC→ETH→SOL); a **single** Back returns to the Market list (previously required one Back per tap). Confirmed exactly one `MainActivity` instance (singleTop working).
- [x] Android + iOS compile clean (`compileAndroidMain`, `compileKotlinIosSimulatorArm64`); Android `assembleDebug` and iOS simulator build (`xcodebuild`) both succeed.
- [~] iOS 26 simulator (iPhone 17 / iOS 26.5): app built & installed; runtime deep-link check was gated by iOS's "Open in UTXO?" system confirmation dialog. Fix additionally validated by a multi-lens adversarial review confirming the path-replace prevents stacking across all tab scenarios (different-tab taps, same-coin re-tap with no flicker) and that the <iOS26 Compose fallback is already idempotent.

## Checklist
- [x] Code follows project style guidelines
- [x] Relevant targets compile locally
- [x] No breaking changes
