### PR TITLE
[FIX] AI Insights: tolerate unknown JSON keys on iOS/Desktop/Web

### DIFF
--- a/composeApp/src/androidMain/kotlin/App.android.kt
+++ b/composeApp/src/androidMain/kotlin/App.android.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.io.files.Path
 import kotlinx.serialization.json.Json
+import network.newsClientJson
 import org.androdevlinux.utxo.ContextProvider
 import org.androdevlinux.utxo.widget.FavoritesWidgetProvider
 import ui.Settings
@@ -54,17 +55,13 @@ actual fun getWebSocketClient(): HttpClient {
 }
 
 actual fun createNewsHttpClient(): HttpClient {
-    val json = Json {
-        isLenient = true
-        ignoreUnknownKeys = true
-    }
     return HttpClient(Android) {
         install(Logging) {
             logger = Logger.SIMPLE
             level = LogLevel.NONE
         }
         install(ContentNegotiation) {
-            json(json)
+            json(newsClientJson)
         }
         install(HttpTimeout) {
             connectTimeoutMillis = 15_000 // 15 seconds

--- a/composeApp/src/commonMain/kotlin/network/NewsClientJson.kt
+++ b/composeApp/src/commonMain/kotlin/network/NewsClientJson.kt
@@ -1,0 +1,17 @@
+package network
+
+import kotlinx.serialization.json.Json
+
+/**
+ * Shared JSON config for the news/AI HTTP client returned by `createNewsHttpClient()` on every
+ * platform. `ignoreUnknownKeys` lets the OpenAI-compatible AI responses (which carry extra top-level
+ * keys such as `id`, `object`, `created`, `model`, `usage`, …) deserialize into our slim DTOs.
+ *
+ * Kept in one place so the config can't drift apart across the platform `actual`s again — the
+ * previous iOS/Desktop/WasmJS actuals used the bare `json()` default (`ignoreUnknownKeys = false`)
+ * and crashed on the provider's `id` key while Android worked.
+ */
+internal val newsClientJson = Json {
+    isLenient = true
+    ignoreUnknownKeys = true
+}

--- a/composeApp/src/commonTest/kotlin/network/AiInsightResponseTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/AiInsightResponseTest.kt
@@ -1,0 +1,45 @@
+package network
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.decodeFromString
+import model.ChatCompletionResponse
+
+/**
+ * Regression tests for deserializing the OpenAI-compatible AI response through [newsClientJson] —
+ * the exact JSON config the news/AI HTTP client uses on every platform.
+ *
+ * Pollinations returns extra top-level keys (`id`, `object`, `created`, `model`, `usage`, …) that
+ * our slim [ChatCompletionResponse] DTO does not model. Before the fix the iOS/Desktop/WasmJS
+ * clients used the bare `json()` default and threw `unknown key 'id'`; these lock in that the shared
+ * config tolerates those keys and still extracts the message content.
+ */
+class AiInsightResponseTest {
+
+    @Test
+    fun response_with_extra_provider_keys_still_parses() {
+        val sample = """
+            {"id":"pllns_abc","object":"chat.completion","created":1730000000,"model":"openai",
+             "choices":[{"index":0,"finish_reason":"stop",
+               "message":{"role":"assistant","content":"BTC momentum looks constructive."}}],
+             "usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}
+        """.trimIndent()
+
+        val parsed = newsClientJson.decodeFromString<ChatCompletionResponse>(sample)
+
+        assertEquals("BTC momentum looks constructive.", parsed.choices.firstOrNull()?.message?.content)
+    }
+
+    @Test
+    fun choice_with_extra_keys_still_parses() {
+        // Unknown keys nested inside a choice (e.g. `logprobs`) must not break parsing either.
+        val sample = """
+            {"id":"pllns_def","choices":[{"index":0,"logprobs":null,"finish_reason":"stop",
+               "message":{"role":"assistant","content":"Volatility is elevated.","refusal":null}}]}
+        """.trimIndent()
+
+        val parsed = newsClientJson.decodeFromString<ChatCompletionResponse>(sample)
+
+        assertEquals("Volatility is elevated.", parsed.choices.firstOrNull()?.message?.content)
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/App.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/App.desktop.kt
@@ -3,6 +3,7 @@ import io.github.xxfast.kstore.KStore
 import io.github.xxfast.kstore.file.storeOf
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
@@ -17,6 +18,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import kotlinx.io.files.Path
 import net.harawata.appdirs.AppDirsFactory
+import network.newsClientJson
 import ui.Settings
 import java.awt.Desktop
 import java.io.File
@@ -90,7 +92,12 @@ actual fun createNewsHttpClient(): HttpClient {
             level = LogLevel.NONE
         }
         install(ContentNegotiation) {
-            json()
+            json(newsClientJson)
+        }
+        install(HttpTimeout) {
+            connectTimeoutMillis = 15_000
+            socketTimeoutMillis = 30_000
+            requestTimeoutMillis = 45_000
         }
     }
 }

--- a/composeApp/src/iosMain/kotlin/App.ios.kt
+++ b/composeApp/src/iosMain/kotlin/App.ios.kt
@@ -3,6 +3,7 @@ import io.github.xxfast.kstore.KStore
 import io.github.xxfast.kstore.file.storeOf
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.darwin.Darwin
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
@@ -40,6 +41,7 @@ import platform.darwin.DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL
 import platform.darwin.dispatch_queue_create
 import kotlinx.cinterop.ExperimentalForeignApi
 import logging.AppLogger
+import network.newsClientJson
 import ui.Settings
 
 actual fun openLink(link: String) {
@@ -167,7 +169,12 @@ actual fun createNewsHttpClient(): HttpClient {
             level = LogLevel.NONE
         }
         install(ContentNegotiation) {
-            json()
+            json(newsClientJson)
+        }
+        install(HttpTimeout) {
+            connectTimeoutMillis = 15_000
+            socketTimeoutMillis = 30_000
+            requestTimeoutMillis = 45_000
         }
     }
 }

--- a/composeApp/src/wasmJsMain/kotlin/App.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/App.wasmJs.kt
@@ -15,6 +15,7 @@ import kotlinx.browser.window
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import network.newsClientJson
 import ui.Settings
 
 actual fun openLink(link: String) {
@@ -64,7 +65,7 @@ actual fun createNewsHttpClient(): HttpClient {
             level = LogLevel.NONE
         }
         install(ContentNegotiation) {
-            json()
+            json(newsClientJson)
         }
         install(HttpTimeout) {
             connectTimeoutMillis = 10_000


### PR DESCRIPTION
## Description

The **AI Insights** card on the coin detail screen crashed on iOS (and Desktop/Web) with:

```
io.ktor.serialization.JsonConvertException: Encountered an unknown key 'id' at path: $
JSON input: {"id":"pllns_....
```

**Root cause — platform config drift.** `AiInsightService` parses the Pollinations (OpenAI-compatible) response through `createNewsHttpClient()`, an `expect`/`actual` factory. Android built `Json { isLenient = true; ignoreUnknownKeys = true }`, but the **iOS, Desktop, and WasmJS** actuals installed ContentNegotiation with the bare `json()` default (`ignoreUnknownKeys = false`). Pollinations returns extra top-level keys (`id`, `object`, `created`, `model`, `usage`, …) that our slim `ChatCompletionResponse` DTO doesn't model, so `body<ChatCompletionResponse>()` threw on those three platforms while Android worked. Every other JSON client in the repo already sets `ignoreUnknownKeys = true`; these three were the outliers.

## Changes Made

- **`network/NewsClientJson.kt`** (new) — a single shared `newsClientJson` (`isLenient` + `ignoreUnknownKeys`) used as the one source of truth for the news/AI HTTP client, so the config can't drift per platform again.
- **`App.android.kt`, `App.ios.kt`, `App.desktop.kt`, `App.wasmJs.kt`** — all four `createNewsHttpClient()` actuals now use `json(newsClientJson)`; Android's inline `Json` is removed.
- **`App.ios.kt`, `App.desktop.kt`** — added `HttpTimeout` (they had none), for parity with Android/WasmJS so hung AI/news requests hit the service's "Request timed out" branch instead of spinning.
- **`AiInsightResponseTest.kt`** (new, commonTest) — regression test decoding a Pollinations-shaped payload with the extra keys through the shared config.

No changes to DTOs, `AiInsightService`, or any UI/ViewModel — the existing error handling already rethrows `CancellationException`.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance improvement

## Testing Done
- [x] Unit tests added/updated (`AiInsightResponseTest`)
- [x] `iosSimulatorArm64Test` — the exact runtime that crashed: compiles `iosMain` + runs the regression test on Kotlin/Native → pass
- [x] `desktopTest` — compiles `desktopMain` + runs tests on JVM → pass
- [x] `compileKotlinWasmJs` + `compileAndroidMain` → success
- [ ] Live end-to-end on iOS sim with a Pollinations API key (manual — needs the key)

## Checklist
- [x] Code follows project style guidelines (matches repo-wide `ignoreUnknownKeys` convention)
- [x] Tests pass locally
- [x] No breaking changes
