### PR TITLE
[FEATURE] Add clear action to Pollinations API key field

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -213,4 +213,5 @@
     <string name="settings_ai_api_key_label">Pollinations API key</string>
     <string name="settings_ai_api_key_hint">Paste your free key</string>
     <string name="settings_ai_get_key">Get a free API key</string>
+    <string name="settings_ai_clear_key">Clear key</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/SettingsScreen.kt
@@ -115,6 +115,7 @@ import utxo.composeapp.generated.resources.settings_about
 import utxo.composeapp.generated.resources.settings_ai
 import utxo.composeapp.generated.resources.settings_ai_api_key_hint
 import utxo.composeapp.generated.resources.settings_ai_api_key_label
+import utxo.composeapp.generated.resources.settings_ai_clear_key
 import utxo.composeapp.generated.resources.settings_ai_desc
 import utxo.composeapp.generated.resources.settings_ai_get_key
 import utxo.composeapp.generated.resources.settings_all_sources_enabled
@@ -388,6 +389,7 @@ private fun AiInsightsSettings(
     // Seed once; this screen is the only editor, so external re-emissions won't clobber typing.
     var keyText by remember { mutableStateOf(apiKey) }
     var keyVisible by remember { mutableStateOf(false) }
+    val hasKey = keyText.isNotBlank()
 
     Column(
         modifier = Modifier
@@ -424,16 +426,33 @@ private fun AiInsightsSettings(
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
             visualTransformation = if (keyVisible) VisualTransformation.None else PasswordVisualTransformation(),
-            trailingIcon = {
-                IconButton(onClick = { keyVisible = !keyVisible }) {
-                    Icon(
-                        imageVector = if (keyVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                        contentDescription = stringResource(
-                            if (keyVisible) Res.string.ai_hide_key else Res.string.ai_show_key
-                        )
-                    )
+            trailingIcon = if (hasKey) {
+                {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        IconButton(onClick = { keyVisible = !keyVisible }) {
+                            Icon(
+                                imageVector = if (keyVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                                contentDescription = stringResource(
+                                    if (keyVisible) Res.string.ai_hide_key else Res.string.ai_show_key
+                                )
+                            )
+                        }
+                        IconButton(onClick = {
+                            keyText = ""
+                            onApiKeyChange("")
+                            keyVisible = false
+                        }) {
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription = stringResource(Res.string.settings_ai_clear_key)
+                            )
+                        }
+                    }
                 }
+            } else {
+                null
             },
+            shape = RoundedCornerShape(12.dp),
             modifier = Modifier.fillMaxWidth()
         )
 


### PR DESCRIPTION
## Description
Improves the **AI Insights → Pollinations API key** field on the Settings screen. Previously the field had only a show/hide (eye) toggle and no way to clear a stored key without manually selecting and deleting the text. This adds a one-tap clear action and rounds the field's outline to match the rest of the app.

A network "verify key" affordance was explored during development but **intentionally dropped**: `text.pollinations.ai` accepts anonymous and even garbage bearer tokens with HTTP 200 (invalid tokens silently fall back to the free tier) and its auth host isn't reachable, so a validity check would falsely report any string as "verified." Rather than ship a misleading control, only the genuinely useful improvements remain.

## Changes Made
- `ui/SettingsScreen.kt` — `AiInsightsSettings`: add an inline clear (X) `IconButton` that wipes the key (`onApiKeyChange("")`), placed next to the existing show/hide toggle in a trailing `Row`; trailing icons render only while a key is present. Round the `OutlinedTextField` outline to `RoundedCornerShape(12.dp)` to match the app's cards.
- `composeResources/values/strings.xml` — add `settings_ai_clear_key` ("Clear key") for the clear button's content description.

No new dependencies. Key still auto-saves on every keystroke (unchanged).

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Refactoring
- [ ] Documentation update
- [ ] Performance improvement

## Testing Done
- [ ] Unit tests added/updated (UI-only change; existing `AiInsight` tests unaffected and pass)
- [x] Manual testing on Desktop — drove Settings → AI Insights: clear-X appears only with a key, clears the field and stored value; rounded outline verified
- [ ] Manual testing on Android
- [ ] Manual testing on iOS
- Compiles cleanly on iOS (`compileKotlinIosSimulatorArm64`), Android (`compileAndroidMain`), and Desktop (`compileKotlinDesktop`); `desktopTest` green.

## Checklist
- [x] Code follows project style guidelines (Material 3, `MaterialTheme.colorScheme.*`, `stringResource`)
- [x] Tests pass locally
- [x] No breaking changes

## Related Issues
N/A
