### PR TITLE
fix(news): decode HTML entities in RSS titles and descriptions

### DIFF
--- a/composeApp/src/commonMain/kotlin/ktx/HtmlEntities.kt
+++ b/composeApp/src/commonMain/kotlin/ktx/HtmlEntities.kt
@@ -1,0 +1,141 @@
+package ktx
+
+/**
+ * Decodes HTML/XML character entities in [this] string, in pure common code
+ * (no `java.*` or other platform dependency).
+ *
+ * The RSS feeds UTXO pulls (BeInCrypto, U.Today, CoinTelegraph, …) encode
+ * punctuation as numeric character references directly in `<title>` — e.g.
+ * `Cowen&#8217;s` (’), `Bitmine &#8211; now` (–). Because [network.NewsService]
+ * extracts tag content with a regex rather than a real XML parser, nothing
+ * decodes those references and they render literally. The old cleanup only
+ * handled a handful of named refs (`&amp; &lt; &#39; …`), which is why some
+ * titles decoded and others (`&#8217;`) did not.
+ *
+ * Handles:
+ *  - decimal numeric refs — `&#8217;`
+ *  - hex numeric refs — `&#x2019;` / `&#X2019;` (including code points above the
+ *    BMP, emitted as a surrogate pair)
+ *  - named refs — `&amp; &lt; &gt; &quot; &apos; &rsquo; &mdash; …`
+ *
+ * A single left-to-right pass decodes each reference exactly once, so a bare
+ * `&` that is not part of a reference ("Tom & Jerry", "R&D; team") is preserved.
+ * Unknown named refs and malformed / oversized sequences are left untouched.
+ */
+fun String.decodeHtmlEntities(): String {
+    if (indexOf('&') < 0) return this // fast path: nothing to decode
+
+    val sb = StringBuilder(length)
+    var i = 0
+    while (i < length) {
+        val c = this[i]
+        if (c == '&') {
+            val semi = indexOfSemicolon(i + 1)
+            if (semi > i) {
+                val decoded = decodeEntity(substring(i + 1, semi))
+                if (decoded != null) {
+                    sb.append(decoded)
+                    i = semi + 1
+                    continue
+                }
+            }
+        }
+        sb.append(c)
+        i++
+    }
+    return sb.toString()
+}
+
+/** Longest reference body we consider (e.g. `#x10FFFF` is 8 chars). */
+private const val MAX_ENTITY_BODY = 12
+
+/**
+ * Index of the terminating `;` for a reference that starts just before [from],
+ * or -1 if there isn't a plausible one. Bails on `&`/whitespace (never part of a
+ * reference) so a stray `&` can't swallow following text, and caps the scan so a
+ * lone `&` doesn't run to a far-away `;`.
+ */
+private fun String.indexOfSemicolon(from: Int): Int {
+    val limit = minOf(length, from + MAX_ENTITY_BODY)
+    var i = from
+    while (i < limit) {
+        when (this[i]) {
+            ';' -> return i
+            '&', ' ', '\n', '\t', '\r', '<', '>' -> return -1
+        }
+        i++
+    }
+    return -1
+}
+
+private fun decodeEntity(body: String): String? {
+    if (body.isEmpty()) return null
+    return if (body[0] == '#') {
+        val rest = body.substring(1)
+        val code = if (rest.isNotEmpty() && (rest[0] == 'x' || rest[0] == 'X')) {
+            rest.substring(1).toIntOrNull(16)
+        } else {
+            rest.toIntOrNull(10)
+        }
+        code?.let { codePointToString(it) }
+    } else {
+        NAMED_ENTITIES[body]
+    }
+}
+
+/** Converts a Unicode code point to a String, emitting a surrogate pair above the BMP. */
+private fun codePointToString(cp: Int): String? = when {
+    cp <= 0 || cp > 0x10FFFF -> null
+    cp in 0xD800..0xDFFF -> null // lone surrogate: invalid
+    cp <= 0xFFFF -> cp.toChar().toString()
+    else -> {
+        val v = cp - 0x10000
+        val high = (0xD800 + (v shr 10)).toChar()
+        val low = (0xDC00 + (v and 0x3FF)).toChar()
+        "$high$low"
+    }
+}
+
+/**
+ * Common named references. Numeric refs cover everything else generically, so
+ * this only needs the names that actually appear in feeds (punctuation, symbols,
+ * currency, and accented letters common in author names). Case-sensitive, per
+ * the HTML spec.
+ */
+private val NAMED_ENTITIES: Map<String, String> = mapOf(
+    // XML predefined
+    "amp" to "&", "lt" to "<", "gt" to ">", "quot" to "\"", "apos" to "'",
+    // spaces & dashes
+    "nbsp" to " ", "ensp" to " ", "emsp" to " ", "thinsp" to " ",
+    "shy" to "­", "ndash" to "–", "mdash" to "—", "hellip" to "…",
+    // quotes
+    "lsquo" to "‘", "rsquo" to "’", "sbquo" to "‚",
+    "ldquo" to "“", "rdquo" to "”", "bdquo" to "„",
+    "laquo" to "«", "raquo" to "»", "lsaquo" to "‹", "rsaquo" to "›",
+    "prime" to "′", "Prime" to "″",
+    // punctuation & symbols
+    "middot" to "·", "bull" to "•", "dagger" to "†", "Dagger" to "‡",
+    "permil" to "‰", "sect" to "§", "para" to "¶", "deg" to "°",
+    "copy" to "©", "reg" to "®", "trade" to "™",
+    // currency
+    "cent" to "¢", "pound" to "£", "curren" to "¤", "yen" to "¥",
+    "euro" to "€",
+    // math / fractions
+    "plusmn" to "±", "times" to "×", "divide" to "÷", "minus" to "−",
+    "frac12" to "½", "frac14" to "¼", "frac34" to "¾",
+    "sup1" to "¹", "sup2" to "²", "sup3" to "³",
+    "ne" to "≠", "le" to "≤", "ge" to "≥", "infin" to "∞",
+    // common accented letters (feeds sometimes use named refs in author names)
+    "agrave" to "à", "aacute" to "á", "acirc" to "â", "atilde" to "ã",
+    "auml" to "ä", "aring" to "å", "aelig" to "æ", "ccedil" to "ç",
+    "egrave" to "è", "eacute" to "é", "ecirc" to "ê", "euml" to "ë",
+    "igrave" to "ì", "iacute" to "í", "icirc" to "î", "iuml" to "ï",
+    "ntilde" to "ñ", "ograve" to "ò", "oacute" to "ó", "ocirc" to "ô",
+    "otilde" to "õ", "ouml" to "ö", "oslash" to "ø", "ugrave" to "ù",
+    "uacute" to "ú", "ucirc" to "û", "uuml" to "ü", "yacute" to "ý",
+    "yuml" to "ÿ", "szlig" to "ß",
+    "Agrave" to "À", "Aacute" to "Á", "Acirc" to "Â", "Auml" to "Ä",
+    "Aring" to "Å", "AElig" to "Æ", "Ccedil" to "Ç", "Egrave" to "È",
+    "Eacute" to "É", "Ecirc" to "Ê", "Euml" to "Ë", "Ntilde" to "Ñ",
+    "Oacute" to "Ó", "Ouml" to "Ö", "Oslash" to "Ø", "Uuml" to "Ü",
+)

--- a/composeApp/src/commonMain/kotlin/network/NewsService.kt
+++ b/composeApp/src/commonMain/kotlin/network/NewsService.kt
@@ -6,6 +6,7 @@ import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.request.get
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpStatusCode
+import ktx.decodeHtmlEntities
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
@@ -236,25 +237,18 @@ class NewsService {
 
     private fun cleanHtml(html: String): String {
         if (html.isEmpty()) return ""
-        
+
         return html
             // Remove CDATA tags first if present
             .replace(Regex("(?s)<!\\[CDATA\\[(.*?)\\]\\]>"), "$1")
             // Remove HTML tags
             .replace(Regex("<[^>]+>"), "")
-            // Decode HTML entities
-            .replace("&lt;", "<")
-            .replace("&gt;", ">")
-            .replace("&amp;", "&")
-            .replace("&quot;", "\"")
-            .replace("&#39;", "'")
-            .replace("&apos;", "'")
-            .replace("&nbsp;", " ")
-            .replace("&mdash;", "—")
-            .replace("&ndash;", "–")
-            .replace("&hellip;", "...")
-            // Clean up extra whitespace
-            .replace(Regex("\\s+"), " ")
+            // Decode HTML entities — numeric (&#8217;, &#x2019;) and named
+            // (&amp; &rsquo; &mdash; …). Replaces the old hand-rolled subset that
+            // left &#8217; and friends rendering literally.
+            .decodeHtmlEntities()
+            // Clean up extra whitespace (including any decoded &nbsp;)
+            .replace(Regex("[\\s\\u00A0]+"), " ")
             .trim()
     }
 

--- a/composeApp/src/commonTest/kotlin/ktx/HtmlEntitiesTest.kt
+++ b/composeApp/src/commonTest/kotlin/ktx/HtmlEntitiesTest.kt
@@ -1,0 +1,88 @@
+package ktx
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+/**
+ * Tests for [decodeHtmlEntities], the pure-common HTML entity decoder that fixes
+ * RSS news titles rendering literal `&#8217;` etc. Covers numeric (decimal/hex,
+ * incl. astral surrogate pairs), named refs, and the "leave non-references alone"
+ * guarantee.
+ */
+class HtmlEntitiesTest {
+
+    @Test
+    fun decodesDecimalNumericRefs() {
+        assertEquals("Cowen’s", "Cowen&#8217;s".decodeHtmlEntities())      // right single quote
+        assertEquals("A – B", "A &#8211; B".decodeHtmlEntities())          // en dash
+        assertEquals("A — B", "A &#8212; B".decodeHtmlEntities())          // em dash
+        assertEquals("can't", "can&#39;t".decodeHtmlEntities())                 // ASCII apostrophe
+        assertEquals("100€", "100&#8364;".decodeHtmlEntities())            // euro
+    }
+
+    @Test
+    fun decodesHexNumericRefs() {
+        assertEquals("’", "&#x2019;".decodeHtmlEntities())
+        assertEquals("’", "&#X2019;".decodeHtmlEntities())                 // uppercase X
+        assertEquals("😀", "&#x1F600;".decodeHtmlEntities())          // 😀 — above the BMP (surrogate pair)
+    }
+
+    @Test
+    fun decodesNamedRefs() {
+        assertEquals("a & b", "a &amp; b".decodeHtmlEntities())
+        assertEquals("<tag>", "&lt;tag&gt;".decodeHtmlEntities())
+        assertEquals("\"quoted\"", "&quot;quoted&quot;".decodeHtmlEntities())
+        assertEquals("it's", "it&apos;s".decodeHtmlEntities())
+        assertEquals("“curly”", "&ldquo;curly&rdquo;".decodeHtmlEntities())
+        assertEquals("em—dash", "em&mdash;dash".decodeHtmlEntities())
+        assertEquals("Beyoncé", "Beyonc&eacute;".decodeHtmlEntities())
+    }
+
+    @Test
+    fun decodesRealWorldTitles() {
+        assertEquals(
+            "Benjamin Cowen’s New Memo Points to Q4 Bitcoin Bottom Near \$44,000",
+            "Benjamin Cowen&#8217;s New Memo Points to Q4 Bitcoin Bottom Near \$44,000".decodeHtmlEntities(),
+        )
+        assertEquals(
+            "Bitcoin treasury company offers 10% income and still can’t sell nearly half its shares",
+            "Bitcoin treasury company offers 10% income and still can&#8217;t sell nearly half its shares".decodeHtmlEntities(),
+        )
+        assertEquals(
+            "Bitmine nears its Ethereum buying limit – Now it needs demand",
+            "Bitmine nears its Ethereum buying limit &#8211; Now it needs demand".decodeHtmlEntities(),
+        )
+    }
+
+    @Test
+    fun leavesNonReferencesUntouched() {
+        assertEquals("Tom & Jerry", "Tom & Jerry".decodeHtmlEntities())
+        assertEquals("R&D; team", "R&D; team".decodeHtmlEntities())
+        assertEquals("100% & up", "100% & up".decodeHtmlEntities())
+        assertEquals("plain text", "plain text".decodeHtmlEntities())
+        // no '&' at all → returns the same instance (fast path)
+        val plain = "nothing to decode here"
+        assertSame(plain, plain.decodeHtmlEntities())
+    }
+
+    @Test
+    fun leavesMalformedOrUnknownRefsAsIs() {
+        assertEquals("&", "&".decodeHtmlEntities())
+        assertEquals("&;", "&;".decodeHtmlEntities())
+        assertEquals("&#;", "&#;".decodeHtmlEntities())
+        assertEquals("&#8217", "&#8217".decodeHtmlEntities())        // no semicolon
+        assertEquals("&#xZZ;", "&#xZZ;".decodeHtmlEntities())        // invalid hex
+        assertEquals("&foobar;", "&foobar;".decodeHtmlEntities())    // unknown named ref
+        assertEquals("&#xD800;", "&#xD800;".decodeHtmlEntities())    // lone surrogate → invalid, left as-is
+        assertEquals("&#0;", "&#0;".decodeHtmlEntities())            // null code point → left as-is
+    }
+
+    @Test
+    fun handlesMultipleAndAdjacentRefs() {
+        assertEquals("a’b’c", "a&#8217;b&#8217;c".decodeHtmlEntities())
+        assertEquals("<>&", "&lt;&gt;&amp;".decodeHtmlEntities())
+        assertEquals("&&&", "&&&".decodeHtmlEntities())
+        assertEquals("", "".decodeHtmlEntities())
+    }
+}


### PR DESCRIPTION
## Summary

Fixes RSS news titles/descriptions rendering raw HTML entities (e.g. `Cowen&#8217;s`, `Bitmine &#8211; now`) instead of decoded characters on the Coin Detail → Latest News list.

## Root cause

`NewsService.parseRSSFeed` extracts tag content with a **regex, not a real XML parser**, and `cleanHtml` only decoded a small hardcoded subset (`&amp; &lt; &#39; &nbsp; &mdash; …`). Numeric refs like `&#8217;` / `&#8211;` and named ones like `&rsquo;` fell straight through — which is exactly why some titles decoded (`&#39;`) and others didn't (`&#8217;`). The feeds are single-encoded (confirmed against BeInCrypto/U.Today/CryptoSlate), so one decode pass is sufficient.

## Changes

- **`ktx/decodeHtmlEntities`** (new, pure common — no `java.*`): single left-to-right pass decoding decimal (`&#8217;`), hex (`&#x2019;`, incl. code points above the BMP via surrogate pairs), and named (`&rsquo; &mdash; …`) references. A bare `&` ("Tom & Jerry", "R&D; team") and malformed/unknown refs are left untouched.
- **`NewsService.cleanHtml`** now uses it (runs on **both** title and description); the whitespace pass also collapses decoded `&nbsp;`.
- **`HtmlEntitiesTest`** — 7 cases incl. the real-world failing titles, malformed refs, surrogate pairs, and the "leave non-references alone" guarantee.

## Verification

- `:composeApp:desktopTest --tests "ktx.HtmlEntitiesTest"` → **7 passed, 0 failures**.
- commonMain compiles for JVM (desktopTest) and Android (installDebug).
- **On-device**: built + installed on the emulator, opened BTC → Latest News — `XRP's`, `Bitcoin's`, `market's`, `this week's` all render `’`; no `&#8217;` remaining in titles or descriptions.
