### PR TITLE
feat(insights): make AI Insights selectable and copyable

### DIFF
--- a/composeApp/src/androidMain/kotlin/App.android.kt
+++ b/composeApp/src/androidMain/kotlin/App.android.kt
@@ -1,4 +1,6 @@
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.net.ConnectivityManager
@@ -119,6 +121,12 @@ actual fun openLink(link: String) {
         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     }
     context.startActivity(intent)
+}
+
+actual fun copyToClipboard(text: String) {
+    val context = ContextProvider.getContext()
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    clipboard.setPrimaryClip(ClipData.newPlainText(null, text))
 }
 
 actual fun syncSettingsToWidget(settings: Settings) {

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -205,6 +205,8 @@
     <string name="ai_insights_disclaimer">AI-generated overview from 24h data and news — not financial advice.</string>
     <string name="ai_insights_error">Couldn\'t generate insights right now.</string>
     <string name="ai_insights_retry">Retry</string>
+    <string name="ai_insights_copy">Copy insights</string>
+    <string name="ai_insights_copied">Insights copied</string>
     <string name="ai_insights_rate_limited">Rate limit reached. Try again shortly, or add a free llm7.io token in Settings for higher limits.</string>
     <string name="ai_insights_rate_limited_stale">Rate limit reached — showing the previous overview.</string>
     <string name="ai_show_key">Show token</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -206,7 +206,7 @@
     <string name="ai_insights_error">Couldn\'t generate insights right now.</string>
     <string name="ai_insights_retry">Retry</string>
     <string name="ai_insights_copy">Copy insights</string>
-    <string name="ai_insights_copied">Insights copied</string>
+    <string name="ai_insights_copied">Copied</string>
     <string name="ai_insights_rate_limited">Rate limit reached. Try again shortly, or add a free llm7.io token in Settings for higher limits.</string>
     <string name="ai_insights_rate_limited_stale">Rate limit reached — showing the previous overview.</string>
     <string name="ai_show_key">Show token</string>

--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -383,8 +383,10 @@ expect fun openLink(link: String)
 /**
  * Puts [text] on the system clipboard.
  *
- * Compose's common `Clipboard` API can't build a plain-text `ClipEntry` off wasm yet, so this goes
- * through each platform's own clipboard instead of the deprecated `LocalClipboardManager`.
+ * `LocalClipboard` is common in CMP 1.11.1, but the only helper that builds a plain-text
+ * `ClipEntry` — `ClipEntry.Companion.withPlainText` — ships in the wasm-js source set alone, so
+ * common code can't construct one. That leaves the deprecated `LocalClipboardManager` or this:
+ * each platform's own clipboard, reached the same way [openLink] reaches each platform's browser.
  */
 expect fun copyToClipboard(text: String)
 

--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -380,6 +380,14 @@ expect fun getKStore(): KStore<ui.Settings>
 
 expect fun openLink(link: String)
 
+/**
+ * Puts [text] on the system clipboard.
+ *
+ * Compose's common `Clipboard` API can't build a plain-text `ClipEntry` off wasm yet, so this goes
+ * through each platform's own clipboard instead of the deprecated `LocalClipboardManager`.
+ */
+expect fun copyToClipboard(text: String)
+
 expect fun createNewsHttpClient(): HttpClient
 
 expect fun wrapRssUrlForPlatform(url: String): List<String>

--- a/composeApp/src/commonMain/kotlin/ui/CoinDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/CoinDetailScreen.kt
@@ -20,11 +20,14 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Article
 import androidx.compose.material.icons.automirrored.filled.ShowChart
 import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Refresh
@@ -59,6 +62,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import copyToClipboard
+import kotlinx.coroutines.delay
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import ktx.buildStyledSymbol
@@ -80,6 +85,8 @@ import ui.utils.isDarkTheme
 import ui.utils.shimmerEffect
 import utxo.composeapp.generated.resources.Res
 import utxo.composeapp.generated.resources.ai_insights
+import utxo.composeapp.generated.resources.ai_insights_copied
+import utxo.composeapp.generated.resources.ai_insights_copy
 import utxo.composeapp.generated.resources.ai_insights_disclaimer
 import utxo.composeapp.generated.resources.ai_insights_error
 import utxo.composeapp.generated.resources.ai_insights_loading
@@ -503,6 +510,15 @@ fun AiInsightCard(
     val showLoading = isLoading ||
         (!hasTicker && error == null && !rateLimited && insight == null)
 
+    // Keyed on the text so a regenerated overview always starts from the un-copied icon.
+    var copied by remember(insight) { mutableStateOf(false) }
+    LaunchedEffect(copied) {
+        if (copied) {
+            delay(2000)
+            copied = false
+        }
+    }
+
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -534,13 +550,39 @@ fun AiInsightCard(
                         fontWeight = FontWeight.Bold
                     )
                 }
-                if (!showLoading && (insight != null || error != null)) {
-                    IconButton(onClick = onRetry, modifier = Modifier.size(32.dp)) {
-                        Icon(
-                            imageVector = Icons.Default.Refresh,
-                            contentDescription = stringResource(Res.string.ai_insights_retry),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    if (!showLoading && insight != null) {
+                        IconButton(
+                            onClick = {
+                                copyToClipboard(insight)
+                                copied = true
+                            },
+                            modifier = Modifier.size(32.dp)
+                        ) {
+                            Icon(
+                                imageVector = if (copied) Icons.Default.Check else Icons.Default.ContentCopy,
+                                contentDescription = stringResource(
+                                    if (copied) Res.string.ai_insights_copied else Res.string.ai_insights_copy
+                                ),
+                                tint = if (copied) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                }
+                            )
+                        }
+                    }
+                    if (!showLoading && (insight != null || error != null)) {
+                        IconButton(onClick = onRetry, modifier = Modifier.size(32.dp)) {
+                            Icon(
+                                imageVector = Icons.Default.Refresh,
+                                contentDescription = stringResource(Res.string.ai_insights_retry),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                     }
                 }
             }
@@ -581,11 +623,14 @@ fun AiInsightCard(
                 // than the limit notice, so a throttled Retry demotes the limit to a footnote
                 // rather than replacing what the user was reading.
                 insight != null -> {
-                    Text(
-                        text = insight,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
+                    // Selectable so users can lift a single line out instead of the whole overview.
+                    SelectionContainer {
+                        Text(
+                            text = insight,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
                     if (rateLimited) {
                         Spacer(modifier = Modifier.height(8.dp))
                         Text(

--- a/composeApp/src/commonMain/kotlin/ui/CoinDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/ui/CoinDetailScreen.kt
@@ -57,6 +57,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -510,12 +513,15 @@ fun AiInsightCard(
     val showLoading = isLoading ||
         (!hasTicker && error == null && !rateLimited && insight == null)
 
-    // Keyed on the text so a regenerated overview always starts from the un-copied icon.
-    var copied by remember(insight) { mutableStateOf(false) }
-    LaunchedEffect(copied) {
-        if (copied) {
+    // Keyed on the text so a regenerated overview always starts from the un-copied state. A tick
+    // counter rather than a Boolean, because writing `true` over `true` is a structural-equality
+    // no-op — the effect would keep its old key and a repeat tap wouldn't restart the window.
+    var copyTick by remember(insight) { mutableStateOf(0) }
+    val copied = copyTick > 0
+    LaunchedEffect(copyTick) {
+        if (copyTick > 0) {
             delay(2000)
-            copied = false
+            copyTick = 0
         }
     }
 
@@ -554,19 +560,31 @@ fun AiInsightCard(
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    if (!showLoading && insight != null) {
+                    // Status lives in a live region rather than in the button's accessible name:
+                    // a label swap on an already-focused control isn't announced, and the name
+                    // should keep describing the action, not report a past event.
+                    if (copied) {
+                        Text(
+                            text = stringResource(Res.string.ai_insights_copied),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite }
+                        )
+                    }
+                    // Mirrors the `when` branch below that renders the text: an error takes over the
+                    // body even while a previous overview is retained, and copying what isn't on
+                    // screen would be a lie.
+                    if (!showLoading && error == null && insight != null) {
                         IconButton(
                             onClick = {
                                 copyToClipboard(insight)
-                                copied = true
+                                copyTick++
                             },
                             modifier = Modifier.size(32.dp)
                         ) {
                             Icon(
                                 imageVector = if (copied) Icons.Default.Check else Icons.Default.ContentCopy,
-                                contentDescription = stringResource(
-                                    if (copied) Res.string.ai_insights_copied else Res.string.ai_insights_copy
-                                ),
+                                contentDescription = stringResource(Res.string.ai_insights_copy),
                                 tint = if (copied) {
                                     MaterialTheme.colorScheme.primary
                                 } else {

--- a/composeApp/src/desktopMain/kotlin/App.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/App.desktop.kt
@@ -21,6 +21,8 @@ import net.harawata.appdirs.AppDirsFactory
 import network.newsClientJson
 import ui.Settings
 import java.awt.Desktop
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
 import java.io.File
 import java.net.InetSocketAddress
 import java.net.Socket
@@ -109,6 +111,10 @@ actual fun wrapRssUrlForPlatform(url: String): List<String> {
 
 actual fun openLink(link: String) {
     Desktop.getDesktop().browse(URI(link));
+}
+
+actual fun copyToClipboard(text: String) {
+    Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(text), null)
 }
 
 actual fun getPendingCoinDetailFromIntent(): Pair<String, String>? {

--- a/composeApp/src/desktopMain/kotlin/App.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/App.desktop.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.isActive
 import kotlinx.io.files.Path
+import logging.AppLogger
 import net.harawata.appdirs.AppDirsFactory
 import network.newsClientJson
 import ui.Settings
@@ -114,7 +115,20 @@ actual fun openLink(link: String) {
 }
 
 actual fun copyToClipboard(text: String) {
-    Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(text), null)
+    // Win32 hands out an exclusive clipboard lock, so setContents throws IllegalStateException
+    // whenever a clipboard manager or an RDP session happens to hold it. Retry once, then give up
+    // quietly — this runs straight off an onClick, and an escaped throw kills pointer dispatch.
+    repeat(2) { attempt ->
+        val result = runCatching {
+            Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(text), null)
+        }
+        if (result.isSuccess) return
+        if (attempt == 1) {
+            AppLogger.logger.e(throwable = result.exceptionOrNull()) { "Failed to copy to clipboard" }
+        } else {
+            Thread.sleep(50)
+        }
+    }
 }
 
 actual fun getPendingCoinDetailFromIntent(): Pair<String, String>? {

--- a/composeApp/src/iosMain/kotlin/App.ios.kt
+++ b/composeApp/src/iosMain/kotlin/App.ios.kt
@@ -37,6 +37,7 @@ import platform.Network.nw_path_monitor_set_update_handler
 import platform.Network.nw_path_monitor_start
 import platform.Network.nw_path_status_satisfied
 import platform.UIKit.UIApplication
+import platform.UIKit.UIPasteboard
 import platform.darwin.DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL
 import platform.darwin.dispatch_queue_create
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -59,6 +60,10 @@ actual fun openLink(link: String) {
     }.getOrElse {
         AppLogger.logger.e(throwable = it) { "Failed to open URL: $link" }
     }
+}
+
+actual fun copyToClipboard(text: String) {
+    UIPasteboard.generalPasteboard.string = text
 }
 
 

--- a/composeApp/src/wasmJsMain/kotlin/App.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/App.wasmJs.kt
@@ -15,12 +15,39 @@ import kotlinx.browser.window
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlin.js.ExperimentalWasmJsInterop
 import network.newsClientJson
 import ui.Settings
 
 actual fun openLink(link: String) {
     window.open(link)
 }
+
+actual fun copyToClipboard(text: String) {
+    writeClipboardText(text)
+}
+
+/**
+ * `navigator.clipboard` only exists in secure contexts, so plain-http builds fall back to the
+ * legacy hidden-textarea + `execCommand` path.
+ */
+@OptIn(ExperimentalWasmJsInterop::class)
+private fun writeClipboardText(text: String): Unit = js(
+    """{
+        if (window.isSecureContext && navigator.clipboard) {
+            navigator.clipboard.writeText(text).catch(function () {});
+        } else {
+            var area = document.createElement('textarea');
+            area.value = text;
+            area.style.position = 'fixed';
+            area.style.opacity = '0';
+            document.body.appendChild(area);
+            area.select();
+            document.execCommand('copy');
+            document.body.removeChild(area);
+        }
+    }"""
+)
 
 actual class NetworkConnectivityObserver {
     actual fun observe(): Flow<NetworkStatus?> = callbackFlow {


### PR DESCRIPTION
## Summary

The AI Insights card was read-only — you could see the overview but not lift a line of it out into a note or a message. This makes the text selectable and adds an explicit copy affordance.

- The overview body is wrapped in a `SelectionContainer`, so long-press (mobile) or drag (desktop/web) selects any part of it.
- A copy `IconButton` sits next to the existing refresh button in the card header, shown only when the overview is actually the thing on screen. Tapping it swaps the icon to a primary-tinted check and shows a `Copied` label for 2s; that label is a `Polite` live region, so the confirmation is announced rather than left as a purely visual cue.
- The confirmation is driven by a tick counter keyed on the insight text, so a regenerated overview resets to the un-copied icon and a repeat tap restarts the window.

## Why a new expect/actual instead of Compose's clipboard

Compose Multiplatform 1.11.1 exposes `LocalClipboard` in common code, but `ClipEntry.Companion.withPlainText` only exists in the wasm-js source set — the desktop artifact has no way to build a plain-text `ClipEntry` from common code. The remaining common option is `LocalClipboardManager`, which is deprecated in this version.

Rather than ship a deprecated call, this adds `expect fun copyToClipboard(text: String)` in `commonMain/kotlin/App.kt`, directly alongside the existing `openLink` expect, with four native actuals:

| Target | Implementation |
| --- | --- |
| Android | `ClipboardManager.setPrimaryClip(ClipData.newPlainText(...))` |
| iOS | `UIPasteboard.generalPasteboard.string` |
| Desktop | `Toolkit.getDefaultToolkit().systemClipboard.setContents(StringSelection(...))` |
| Web | `navigator.clipboard.writeText`, with a hidden-textarea `execCommand` fallback for non-secure contexts |

## Self-review round (second commit)

An adversarial pass over the first commit found four real defects, all fixed in `6dd4b98`:

1. **Copy button showed in the error state.** The body `when` puts `error != null` ahead of `insight != null`, and the ViewModel deliberately retains the previous overview on failure — so after a failed retry the card said "Couldn't generate insights" while still offering Copy for text that was no longer rendered. The guard now mirrors the branch that renders the text.
2. **Repeat taps didn't restart the confirmation.** `copied = true` written over `true` is a structural-equality no-op, so `LaunchedEffect(copied)` kept its key and the original `delay(2000)` ran to completion — a second copy at t=1.9s lost its check icon 100ms later. Replaced with a tick counter that re-keys the effect.
3. **The confirmation was invisible to screen readers.** A `contentDescription` swap on an already-focused control isn't announced, and it puts transient status in the control's accessible name (WCAG 4.1.2). Status moved to a `Polite` live region; the button keeps `Copy insights` as its label.
4. **Desktop clipboard could throw out of `onClick`.** Win32 hands out an exclusive clipboard lock, so `setContents` throws `IllegalStateException` whenever a clipboard manager or RDP session holds it — and Windows is a shipped target (`TargetFormat.Msi`). Now retries once and logs, matching how `openLink` guards on iOS.

Two further candidate findings were investigated and rejected: the copy payload excluding the disclaimer (a product decision, not a defect — the button says "Copy insights"), and the wasm `.catch` swallowing a rejection (the fallback path and Compose's microtask dispatch make the claimed failure unreachable as described).

## Test plan

Compiled and tested locally:

```
./gradlew :composeApp:compileKotlinDesktop \
          :composeApp:compileKotlinIosSimulatorArm64 \
          :composeApp:compileAndroidMain \
          :composeApp:compileKotlinWasmJs \
          :composeApp:desktopTest
```

All green, no new warnings. Lint was not run — this project has no `ktlintCheck` task despite `CLAUDE.md` listing one.

**Not verified end to end.** The insight body needs a live network round-trip to populate, so the copy and selection behaviour has not been exercised on a running device or browser. Worth a manual pass on at least Android and web before merge:

- [ ] Android — copy button writes to the clipboard, check icon appears and reverts after ~2s
- [ ] Web — copy works over HTTPS (the `navigator.clipboard` path)
- [ ] Any platform — long-press/drag selects the overview text without fighting the list scroll

## Risks

- `SelectionContainer` sits inside a `LazyColumn` item; touch selection and list scrolling share the long-press gesture, so the scroll feel around that card is the thing most likely to regress.
- The web fallback path (`execCommand`) only runs on non-secure origins and is untested.
