### PR TITLE
fix(strings): render apostrophes instead of a literal backslash

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -131,7 +131,7 @@
     <string name="settings_edit_wallet">Edit wallet</string>
     <string name="settings_wallet_verifying">Verifying on Hyperliquid…</string>
     <string name="settings_wallet_not_found">This address has no Hyperliquid activity</string>
-    <string name="settings_wallet_verify_failed">Couldn\'t verify — check your connection and try again</string>
+    <string name="settings_wallet_verify_failed">Couldn’t verify — check your connection and try again</string>
     <string name="settings_wallet_name">Wallet name</string>
     <string name="settings_wallet_name_hint">Leave blank to use the ENS name or address</string>
     <string name="settings_wallet_label_optional">Label (optional)</string>
@@ -153,7 +153,7 @@
     <string name="settings_bulk_result">Added %1$d of %2$d</string>
     <string name="settings_bulk_status_added">Added</string>
     <string name="settings_bulk_status_no_activity">No activity</string>
-    <string name="settings_bulk_status_failed">Couldn\'t verify</string>
+    <string name="settings_bulk_status_failed">Couldn’t verify</string>
     <string name="settings_wallet_ens_badge">ENS</string>
     <string name="settings_delete">Delete</string>
 
@@ -180,7 +180,7 @@
     <string name="portfolio_no_address_hint">Add your Hyperliquid wallet address in Settings to view your portfolio.</string>
     <string name="portfolio_invalid_address">Invalid wallet address</string>
     <string name="portfolio_invalid_address_hint">The configured address must be 0x followed by 40 hex characters.</string>
-    <string name="portfolio_load_error">Couldn\'t load portfolio</string>
+    <string name="portfolio_load_error">Couldn’t load portfolio</string>
     <string name="portfolio_load_error_hint">Check your connection and try again.</string>
     <string name="portfolio_retry">Retry</string>
     <string name="portfolio_open_settings">Open Settings</string>
@@ -203,7 +203,7 @@
     <string name="ai_insights">AI Insights</string>
     <string name="ai_insights_loading">Analyzing market data and news…</string>
     <string name="ai_insights_disclaimer">AI-generated overview from 24h data and news — not financial advice.</string>
-    <string name="ai_insights_error">Couldn\'t generate insights right now.</string>
+    <string name="ai_insights_error">Couldn’t generate insights right now.</string>
     <string name="ai_insights_retry">Retry</string>
     <string name="ai_insights_rate_limited">Rate limit reached. Try again shortly, or add a free llm7.io token in Settings for higher limits.</string>
     <string name="ai_insights_rate_limited_stale">Rate limit reached — showing the previous overview.</string>


### PR DESCRIPTION
## Summary

Four user-facing error strings used the Android XML escape `\'` for an apostrophe. Compose Multiplatform's `composeResources` parser does not unescape it — unlike AAPT — so the backslash rendered literally on screen.

Caught on an Android emulator: the AI Insights card error state read `Couldn\'t generate insights right now.`

| Line | Key |
| --- | --- |
| 134 | `settings_wallet_verify_failed` |
| 156 | `settings_bulk_status_failed` |
| 183 | `portfolio_load_error` |
| 206 | `ai_insights_error` |

Switched to the typographic apostrophe `’` rather than a bare `'`. The file has no other apostrophes to match, but it already uses `—` (5×) and `…` (6×), so typographic punctuation is the established convention here. A bare `'` would also have worked — these strings never pass through AAPT.

## Test plan

Verified two ways after `./gradlew :androidApp:installDebug`:

**1. The packed resource in the shipped APK** — decoded `assets/composeResources/.../values/strings.commonMain.cvr`:

```
ai_insights_error              -> 'Couldn’t generate insights right now.'
portfolio_load_error           -> 'Couldn’t load portfolio'
settings_bulk_status_failed    -> 'Couldn’t verify'
settings_wallet_verify_failed  -> 'Couldn’t verify — check your connection and try again'
```

**2. Rendered on screen** — forced the AI Insights error state on a Pixel_9a emulator (airplane mode, then Retry) and read it back from the accessibility tree:

```
RENDERED >>> 'Couldn’t generate insights right now.'
literal backslash present in tree: False
```

No source changes, so no compile risk beyond resource generation. The other three strings are behind Settings/Portfolio error paths that were not exercised on device; the APK decode above covers them.