### PR TITLE
perf(insights): reuse a recent overview instead of calling the AI again

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -139,6 +139,7 @@ kotlin {
 
         commonTest.dependencies {
             implementation(kotlin("test"))
+            implementation(libs.kotlinx.coroutines.test)
         }
 
         desktopMain.dependencies {

--- a/composeApp/src/commonMain/kotlin/network/AiInsightCache.kt
+++ b/composeApp/src/commonMain/kotlin/network/AiInsightCache.kt
@@ -15,7 +15,8 @@ import kotlinx.coroutines.sync.withLock
  * change what it says, and [AiInsightService.buildUserPrompt] embeds `lastPrice` at full precision —
  * keying on it would mean never hitting the cache on a liquid pair.
  *
- * Deliberate user actions — the card's Retry, or saving an API token — bypass this entirely.
+ * Deliberate user actions bypass this entirely: the card's Retry, the screen's Refresh, and saving
+ * an API token. Only revisiting a coin is served from here.
  *
  * Lives outside the ViewModel because both it and [AiInsightService] are constructed per screen.
  */

--- a/composeApp/src/commonMain/kotlin/network/AiInsightCache.kt
+++ b/composeApp/src/commonMain/kotlin/network/AiInsightCache.kt
@@ -1,0 +1,77 @@
+package network
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Process-wide cache of generated overviews, keyed by trading pair.
+ *
+ * `CoinDetailViewModel.loadCoinData` runs on every visit to a coin screen, so without this, browsing
+ * between coins spends one llm7.io request per visit — and anonymous callers only get 10 a minute.
+ *
+ * An entry is reused while it is younger than [TTL_MILLIS] and the headline set behind it is
+ * unchanged. The 24h ticker is deliberately *not* part of the key: the overview is qualitative
+ * ("near the 24-hour high", "robust trading activity"), so a few minutes of price drift doesn't
+ * change what it says, and [AiInsightService.buildUserPrompt] embeds `lastPrice` at full precision —
+ * keying on it would mean never hitting the cache on a liquid pair.
+ *
+ * Deliberate user actions — the card's Retry, or saving an API token — bypass this entirely.
+ *
+ * Lives outside the ViewModel because both it and [AiInsightService] are constructed per screen.
+ */
+internal object AiInsightCache {
+
+    /** How long an overview stays presentable as current. */
+    const val TTL_MILLIS: Long = 10 * 60 * 1000L
+
+    /** Bounded so a long browsing session can't grow this without limit. */
+    const val MAX_ENTRIES: Int = 20
+
+    private data class Entry(
+        val text: String,
+        val newsFingerprint: String,
+        val storedAtMillis: Long
+    )
+
+    private val mutex = Mutex()
+
+    /** Insertion-ordered, and re-inserted on read, so the first key is the least recently used. */
+    private val entries = LinkedHashMap<String, Entry>()
+
+    /**
+     * Returns a still-valid overview for [symbol], or null when there is none — which also drops the
+     * stale entry. [nowMillis] is passed in rather than read here so this stays directly testable.
+     */
+    suspend fun get(symbol: String, newsFingerprint: String, nowMillis: Long): String? = mutex.withLock {
+        val entry = entries[symbol] ?: return@withLock null
+
+        val age = nowMillis - entry.storedAtMillis
+        // A negative age means the clock moved backwards; treat that as stale rather than as an
+        // entry that never expires.
+        if (entry.newsFingerprint != newsFingerprint || age !in 0 until TTL_MILLIS) {
+            entries.remove(symbol)
+            return@withLock null
+        }
+
+        // Re-insert to mark it most recently used.
+        entries.remove(symbol)
+        entries[symbol] = entry
+        entry.text
+    }
+
+    suspend fun put(symbol: String, newsFingerprint: String, text: String, nowMillis: Long) {
+        mutex.withLock {
+            entries.remove(symbol)
+            entries[symbol] = Entry(text, newsFingerprint, nowMillis)
+            while (entries.size > MAX_ENTRIES) {
+                val leastRecentlyUsed = entries.keys.firstOrNull() ?: break
+                entries.remove(leastRecentlyUsed)
+            }
+        }
+    }
+
+    /** Drops everything. Used by tests to isolate cases against this shared object. */
+    suspend fun clear() {
+        mutex.withLock { entries.clear() }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/network/AiInsightService.kt
+++ b/composeApp/src/commonMain/kotlin/network/AiInsightService.kt
@@ -199,6 +199,24 @@ class AiInsightService {
             }
         }
 
+        /**
+         * Identity of the headlines that would reach the model — the part of the input that
+         * actually changes what the overview says. Takes the same [MAX_NEWS_ITEMS] slice as
+         * [buildUserPrompt] so the cache key and the prompt can't drift apart.
+         *
+         * Sorted, so this describes the *set* of headlines rather than their order: an overview
+         * built from the same stories is worth reusing however they were arranged. That also keeps
+         * the key stable against any residual ordering jitter between two loads.
+         *
+         * Falls back to the title where a feed gives no link, so two different headlines never
+         * collapse into the same fingerprint.
+         */
+        internal fun newsFingerprint(news: List<NewsItem>): String =
+            news.take(MAX_NEWS_ITEMS)
+                .map { it.link.ifBlank { it.title } }
+                .sorted()
+                .joinToString("\n")
+
         private fun String.collapseWhitespace(): String =
             replace(Regex("\\s+"), " ").trim()
 

--- a/composeApp/src/commonMain/kotlin/ui/CoinDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/ui/CoinDetailViewModel.kt
@@ -16,12 +16,14 @@ import model.NewsItem
 import model.OrderBookData
 import model.RssProvider
 import model.Ticker24hr
+import network.AiInsightCache
 import network.AiInsightService
 import network.NewsService
 import network.OrderBookWebSocketService
 import network.TickerWebSocketService
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import network.HttpClient as NetworkClient
 
@@ -189,13 +191,21 @@ class CoinDetailViewModel : ViewModel() {
                                     val updatedNews = if (news.isNotEmpty()) {
                                         (currentState.news + news)
                                             .distinctBy { it.link }
-                                            .sortedByDescending { item ->
-                                                try {
-                                                    ktx.parseRssDate(item.pubDate)
-                                                } catch (_: Exception) {
-                                                    kotlin.time.Instant.fromEpochMilliseconds(0)
-                                                }
-                                            }
+                                            // Tie-break on the link: sortedBy* is stable, so items
+                                            // sharing a pubDate (and every item with an unparseable
+                                            // one, which all collapse to epoch 0) would otherwise
+                                            // keep whichever order their provider happened to
+                                            // return in. That made both the AI prompt and
+                                            // [AiInsightCache]'s key non-reproducible run to run.
+                                            .sortedWith(
+                                                compareByDescending<NewsItem> { item ->
+                                                    try {
+                                                        ktx.parseRssDate(item.pubDate)
+                                                    } catch (_: Exception) {
+                                                        kotlin.time.Instant.fromEpochMilliseconds(0)
+                                                    }
+                                                }.thenBy { it.link }
+                                            )
                                             .take(50)
                                     } else {
                                         currentState.news
@@ -263,7 +273,8 @@ class CoinDetailViewModel : ViewModel() {
     fun regenerateInsight() {
         val symbol = currentSymbol ?: return
         val ticker = state.value.ticker ?: return
-        generateInsightFor(symbol, ticker, state.value.news)
+        // The user explicitly asked for a new overview, so don't hand back the cached one.
+        generateInsightFor(symbol, ticker, state.value.news, forceRefresh = true)
     }
 
     /**
@@ -281,12 +292,46 @@ class CoinDetailViewModel : ViewModel() {
         currentApiToken = aiApiToken
         val symbol = currentSymbol ?: return
         val ticker = state.value.ticker ?: return
-        generateInsightFor(symbol, ticker, state.value.news)
+        // Saving a token is usually a response to being throttled, so give them a real attempt
+        // rather than the overview the anonymous tier already produced.
+        generateInsightFor(symbol, ticker, state.value.news, forceRefresh = true)
     }
 
-    private fun generateInsightFor(symbol: String, ticker: Ticker24hr, news: List<NewsItem>) {
+    /**
+     * @param forceRefresh skips [AiInsightCache] on the way in. Set for deliberate user actions;
+     *   the automatic path from [loadCoinData] leaves it false so that revisiting a coin within the
+     *   cache TTL costs no llm7.io request.
+     */
+    private fun generateInsightFor(
+        symbol: String,
+        ticker: Ticker24hr,
+        news: List<NewsItem>,
+        forceRefresh: Boolean = false
+    ) {
         insightJob?.cancel()
         insightJob = viewModelScope.launch {
+            val newsFingerprint = AiInsightService.newsFingerprint(news)
+
+            if (!forceRefresh) {
+                val cached = AiInsightCache.get(
+                    symbol = symbol,
+                    newsFingerprint = newsFingerprint,
+                    nowMillis = Clock.System.now().toEpochMilliseconds()
+                )
+                if (cached != null) {
+                    AppLogger.logger.d { "CoinDetailViewModel: reusing cached insight for $symbol" }
+                    state.update {
+                        it.copy(
+                            aiInsight = cached,
+                            isLoadingInsight = false,
+                            insightError = null,
+                            insightRateLimited = false
+                        )
+                    }
+                    return@launch
+                }
+            }
+
             state.update {
                 it.copy(
                     isLoadingInsight = true,
@@ -299,13 +344,21 @@ class CoinDetailViewModel : ViewModel() {
                 val result =
                     aiInsightService.generateInsight(symbol, baseAsset, ticker, news, currentApiToken)
             ) {
-                is AiInsightService.InsightResult.Success -> state.update {
-                    it.copy(
-                        aiInsight = result.text,
-                        isLoadingInsight = false,
-                        insightError = null,
-                        insightRateLimited = false
+                is AiInsightService.InsightResult.Success -> {
+                    AiInsightCache.put(
+                        symbol = symbol,
+                        newsFingerprint = newsFingerprint,
+                        text = result.text,
+                        nowMillis = Clock.System.now().toEpochMilliseconds()
                     )
+                    state.update {
+                        it.copy(
+                            aiInsight = result.text,
+                            isLoadingInsight = false,
+                            insightError = null,
+                            insightRateLimited = false
+                        )
+                    }
                 }
 
                 // Keep any insight already on screen: unlike an auth failure this is routine at the

--- a/composeApp/src/commonMain/kotlin/ui/CoinDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/ui/CoinDetailViewModel.kt
@@ -98,10 +98,17 @@ class CoinDetailViewModel : ViewModel() {
         }
     }
 
+    /**
+     * @param forceInsight regenerates the overview instead of reusing a cached one. Set by
+     *   [refresh] — a pull/tap to refresh is a deliberate "give me current data" gesture, and the
+     *   AI card must not be the one element on the screen that ignores it. The screen's own
+     *   `LaunchedEffect` leaves this false so that merely revisiting a coin costs no request.
+     */
     fun loadCoinData(
         symbol: String,
         enabledRssProviders: Set<String> = RssProvider.DEFAULT_ENABLED_PROVIDERS,
-        aiApiToken: String = ""
+        aiApiToken: String = "",
+        forceInsight: Boolean = false
     ) {
         currentLoadJob?.cancel()
         insightJob?.cancel()
@@ -140,7 +147,7 @@ class CoinDetailViewModel : ViewModel() {
             val news = newsDeferred.await()
 
             if (ticker != null) {
-                generateInsightFor(symbol, ticker, news)
+                generateInsightFor(symbol, ticker, news, forceRefresh = forceInsight)
             } else {
                 state.update { it.copy(isLoadingInsight = false) }
             }
@@ -262,7 +269,7 @@ class CoinDetailViewModel : ViewModel() {
     ) {
         viewModelScope.launch {
             newsService.clearCache()
-            loadCoinData(symbol, enabledRssProviders, aiApiToken)
+            loadCoinData(symbol, enabledRssProviders, aiApiToken, forceInsight = true)
         }
     }
 
@@ -298,9 +305,9 @@ class CoinDetailViewModel : ViewModel() {
     }
 
     /**
-     * @param forceRefresh skips [AiInsightCache] on the way in. Set for deliberate user actions;
-     *   the automatic path from [loadCoinData] leaves it false so that revisiting a coin within the
-     *   cache TTL costs no llm7.io request.
+     * @param forceRefresh skips [AiInsightCache] on the way in. Set for every deliberate user
+     *   action — Retry, Refresh, saving a token. Only the screen's own load-on-open leaves it
+     *   false, so that revisiting a coin within the cache TTL costs no llm7.io request.
      */
     private fun generateInsightFor(
         symbol: String,

--- a/composeApp/src/commonTest/kotlin/network/AiInsightCacheTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/AiInsightCacheTest.kt
@@ -1,0 +1,155 @@
+package network
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.test.runTest
+import model.NewsItem
+
+/**
+ * Unit tests for [AiInsightCache] and the fingerprint it is keyed on.
+ *
+ * These lock in the point of the cache: revisiting a coin inside the TTL must not spend another
+ * llm7.io request, while genuinely new headlines — or an entry that has aged out — must.
+ */
+class AiInsightCacheTest {
+
+    private val t0 = 1_000_000L
+
+    @BeforeTest
+    fun setUp() = runTest { AiInsightCache.clear() }
+
+    @AfterTest
+    fun tearDown() = runTest { AiInsightCache.clear() }
+
+    private fun newsItem(link: String, title: String = "Headline") = NewsItem(
+        title = title,
+        description = "Description",
+        link = link,
+        pubDate = "Wed, 07 Aug 2026 12:00:00 GMT",
+        source = "CoinTelegraph"
+    )
+
+    @Test
+    fun returnsStoredTextWhileFreshAndFingerprintMatches() = runTest {
+        AiInsightCache.put("BTCUSDT", "news-a", "Bitcoin is holding near its 24h high.", t0)
+
+        assertEquals(
+            "Bitcoin is holding near its 24h high.",
+            AiInsightCache.get("BTCUSDT", "news-a", t0 + AiInsightCache.TTL_MILLIS - 1)
+        )
+    }
+
+    @Test
+    fun missesOnceTheEntryReachesTheTtl() = runTest {
+        AiInsightCache.put("BTCUSDT", "news-a", "overview", t0)
+
+        assertNull(AiInsightCache.get("BTCUSDT", "news-a", t0 + AiInsightCache.TTL_MILLIS))
+    }
+
+    @Test
+    fun missesWhenTheHeadlineSetChanged() = runTest {
+        AiInsightCache.put("BTCUSDT", "news-a", "overview", t0)
+
+        assertNull(AiInsightCache.get("BTCUSDT", "news-b", t0 + 1))
+    }
+
+    /** A backwards clock jump must expire the entry, not make it live forever. */
+    @Test
+    fun missesWhenTheClockMovedBackwards() = runTest {
+        AiInsightCache.put("BTCUSDT", "news-a", "overview", t0)
+
+        assertNull(AiInsightCache.get("BTCUSDT", "news-a", t0 - 1))
+    }
+
+    @Test
+    fun keepsSymbolsIndependent() = runTest {
+        AiInsightCache.put("BTCUSDT", "news-a", "bitcoin overview", t0)
+        AiInsightCache.put("ETHUSDT", "news-b", "ether overview", t0)
+
+        assertEquals("bitcoin overview", AiInsightCache.get("BTCUSDT", "news-a", t0 + 1))
+        assertEquals("ether overview", AiInsightCache.get("ETHUSDT", "news-b", t0 + 1))
+    }
+
+    @Test
+    fun evictsTheLeastRecentlyUsedOnceFull() = runTest {
+        repeat(AiInsightCache.MAX_ENTRIES) { i ->
+            AiInsightCache.put("PAIR$i", "news", "overview $i", t0)
+        }
+        // Touch the oldest so it is no longer the least recently used.
+        assertEquals("overview 0", AiInsightCache.get("PAIR0", "news", t0 + 1))
+
+        AiInsightCache.put("NEWPAIR", "news", "newest", t0 + 2)
+
+        assertEquals("overview 0", AiInsightCache.get("PAIR0", "news", t0 + 3))
+        assertEquals("newest", AiInsightCache.get("NEWPAIR", "news", t0 + 3))
+        assertNull(AiInsightCache.get("PAIR1", "news", t0 + 3))
+    }
+
+    @Test
+    fun overwritingRefreshesTheEntryAge() = runTest {
+        AiInsightCache.put("BTCUSDT", "news-a", "first", t0)
+        AiInsightCache.put("BTCUSDT", "news-a", "second", t0 + AiInsightCache.TTL_MILLIS)
+
+        assertEquals(
+            "second",
+            AiInsightCache.get("BTCUSDT", "news-a", t0 + AiInsightCache.TTL_MILLIS + 1)
+        )
+    }
+
+    @Test
+    fun fingerprintTracksTheHeadlinesThatReachTheModel() {
+        val a = listOf(newsItem("https://example.com/1"), newsItem("https://example.com/2"))
+        val b = listOf(newsItem("https://example.com/1"), newsItem("https://example.com/3"))
+
+        assertEquals(AiInsightService.newsFingerprint(a), AiInsightService.newsFingerprint(a))
+        assertEquals(false, AiInsightService.newsFingerprint(a) == AiInsightService.newsFingerprint(b))
+    }
+
+    /**
+     * The news list is built by merging providers that finish in a nondeterministic order, and
+     * `sortedWith` is stable — so two loads of the same stories can order same-timestamp headlines
+     * differently. The fingerprint must not treat that as a change, or the cache never hits.
+     */
+    @Test
+    fun fingerprintIgnoresHeadlineOrder() {
+        val a = listOf(newsItem("https://example.com/1"), newsItem("https://example.com/2"))
+        val reordered = a.reversed()
+
+        assertEquals(
+            AiInsightService.newsFingerprint(a),
+            AiInsightService.newsFingerprint(reordered)
+        )
+    }
+
+    /** Only the first [AiInsightService.MAX_NEWS_ITEMS] reach the prompt, so only they may key it. */
+    @Test
+    fun fingerprintIgnoresHeadlinesBeyondThePromptCap() {
+        val capped = List(AiInsightService.MAX_NEWS_ITEMS) { newsItem("https://example.com/$it") }
+        val extra = capped + newsItem("https://example.com/never-sent")
+
+        assertEquals(
+            AiInsightService.newsFingerprint(capped),
+            AiInsightService.newsFingerprint(extra)
+        )
+    }
+
+    /** Feeds that omit a link must still produce distinct fingerprints for distinct stories. */
+    @Test
+    fun fingerprintFallsBackToTheTitleWhenALinkIsMissing() {
+        val a = listOf(newsItem(link = "", title = "MARA sells reserves"))
+        val b = listOf(newsItem(link = "", title = "Saylor on the Clarity Act"))
+
+        assertEquals(false, AiInsightService.newsFingerprint(a) == AiInsightService.newsFingerprint(b))
+    }
+
+    @Test
+    fun emptyNewsIsAStableFingerprint() {
+        assertEquals(
+            AiInsightService.newsFingerprint(emptyList()),
+            AiInsightService.newsFingerprint(emptyList())
+        )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/network/AiInsightCacheTest.kt
+++ b/composeApp/src/commonTest/kotlin/network/AiInsightCacheTest.kt
@@ -4,6 +4,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlinx.coroutines.test.runTest
 import model.NewsItem
@@ -104,8 +105,11 @@ class AiInsightCacheTest {
         val a = listOf(newsItem("https://example.com/1"), newsItem("https://example.com/2"))
         val b = listOf(newsItem("https://example.com/1"), newsItem("https://example.com/3"))
 
-        assertEquals(AiInsightService.newsFingerprint(a), AiInsightService.newsFingerprint(a))
-        assertEquals(false, AiInsightService.newsFingerprint(a) == AiInsightService.newsFingerprint(b))
+        assertEquals(
+            "https://example.com/1\nhttps://example.com/2",
+            AiInsightService.newsFingerprint(a)
+        )
+        assertNotEquals(AiInsightService.newsFingerprint(a), AiInsightService.newsFingerprint(b))
     }
 
     /**
@@ -142,14 +146,16 @@ class AiInsightCacheTest {
         val a = listOf(newsItem(link = "", title = "MARA sells reserves"))
         val b = listOf(newsItem(link = "", title = "Saylor on the Clarity Act"))
 
-        assertEquals(false, AiInsightService.newsFingerprint(a) == AiInsightService.newsFingerprint(b))
+        assertNotEquals(AiInsightService.newsFingerprint(a), AiInsightService.newsFingerprint(b))
     }
 
+    /** No news is a legitimate state — it must key distinctly, not collide with a real headline. */
     @Test
-    fun emptyNewsIsAStableFingerprint() {
-        assertEquals(
+    fun emptyNewsIsItsOwnFingerprint() {
+        assertEquals("", AiInsightService.newsFingerprint(emptyList()))
+        assertNotEquals(
             AiInsightService.newsFingerprint(emptyList()),
-            AiInsightService.newsFingerprint(emptyList())
+            AiInsightService.newsFingerprint(listOf(newsItem("https://example.com/1")))
         )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ kstore-storage = { module = "io.github.xxfast:kstore-storage", version.ref = "ks
 harawata-appdirs = { module = "net.harawata:appdirs", version.ref = "harawata-appdirs" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutinesVersion" }
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "coroutinesVersion" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutinesVersion" }
 lifecyle-runtime-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "composeLifecyleRuntime" }
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }


### PR DESCRIPTION
## Summary

`loadCoinData` is driven by a `LaunchedEffect(symbol, enabledProvidersKey, settingsLoaded)`, so **every visit to a coin screen spent an llm7.io request**. Open BTC, go back, open BTC again — two calls, seconds apart, for the same thing. Anonymous callers get 10 requests a minute and 60 an hour, so browsing a handful of coins burns through the budget.

Overviews now go in a bounded in-memory LRU (`AiInsightCache`, 20 entries), keyed by trading pair, and are reused for 10 minutes while the headline set behind them is unchanged.

**The 24h ticker is deliberately not part of the key.** `buildUserPrompt` embeds `lastPrice` at full precision, so on a liquid pair the prompt differs on literally every load — an exact-match cache would never hit. The overview is qualitative anyway ("near the 24-hour high", "robust trading activity"), and a few minutes of price drift doesn't change what it says.

Deliberate user actions still force a fresh call and overwrite the entry:
- the card's **Retry**
- **saving an API token** — usually a response to being throttled, so it deserves a real attempt rather than the overview the anonymous tier already produced

In-memory only, so a cold start still fetches fresh — which is what you'd want on launch anyway.

## A latent bug this surfaced

The merged news list is sorted with `sortedByDescending { parseRssDate(pubDate) }`. That sort is **stable**, so headlines sharing a `pubDate` — and every headline whose date fails to parse, which all collapse to epoch 0 — kept whichever order their provider's `async` happened to finish in. Two loads of identical stories could order them differently.

That made the AI prompt itself non-reproducible run to run, and it would have made this cache miss at random. Fixed at the root with a `.thenBy { it.link }` tie-breaker, plus the fingerprint is order-insensitive as defence in depth.

## Test plan

**12 unit tests** in `AiInsightCacheTest` (green on desktop and iosSimulatorArm64) covering: TTL boundary, changed headline set, backwards clock, per-symbol isolation, LRU eviction with recency touch, overwrite refreshing the age, and the fingerprint's order-insensitivity / prompt-cap / missing-link fallback.

All four targets compile; `desktopTest` and `iosSimulatorArm64Test` pass.

**Verified on a Pixel_9a emulator** by reading the rendered text out of the accessibility tree:

| Step | Result |
| --- | --- |
| Visit 1 of ETH/BTC | 703-char overview generated |
| Back, visit 2 | **byte-identical 703 chars, no request** |
| Tap Retry | different overview (500 chars, different price) — cache bypassed |

Before the change, repeat visits produced visibly different wording each time, which is what made the saving observable.

## Note

The card still shows "Analyzing market data and news…" briefly on a cached visit, because `loadCoinData` sets `isLoadingInsight = true` before the news fetch and the cache can only be consulted once the headline set is known. The request is saved either way — this is about the spinner, not the call. Worth a follow-up if the flash bothers you.

Adds `kotlinx-coroutines-test` to `commonTest` (the cache API is suspending, guarded by a `Mutex`).

## Self-review round (second commit)

An adversarial pass over the first commit found one real defect, fixed in `5c07223`:

**The screen's Refresh button stopped regenerating the overview.** `refresh()` routes through `loadCoinData`, so it inherited the `forceRefresh = false` default — the one gesture whose entire purpose is "refetch everything" was the only path still served from cache. It even calls `newsService.clearCache()` first to force a real network re-fetch of every RSS feed, then discarded that work for the AI card. Worse, `loadCoinData` sets `isLoadingInsight = true` before the news fetch, so the user watched the "Analyzing market data and news…" spinner run for the whole round trip and then got byte-identical text back — the UI asserting that re-analysis happened when no request was made. This was a regression against `main`, where every `loadCoinData` regenerated.

Fixed with a `forceInsight` flag on `loadCoinData` that `refresh()` sets; the screen's load-on-open keeps the default. `AiInsightCache`'s KDoc now lists all three bypassing actions.

Also replaced two test assertions that compared a function's output to itself (`f(x) == f(x)`) with real expectations.

Re-verified on the emulator:

| Step | Result |
| --- | --- |
| Open ETH/BTC | 795-char overview generated |
| Tap top-bar Refresh | **695-char overview, different text** — regenerates again |
| Back, revisit | byte-identical 695 chars, no request — cache still works |
